### PR TITLE
Update README for simulator path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # county-emulator
 
 This project is a small prototype for a feudal county simulation. The main
-implementation lives in `fiefdom.py` and uses Tkinter to render maps and
-manage game data.
+implementation now lives in `src/simulator.py` and uses Tkinter to render maps
+and manage game data. Run it with `python src/simulator.py`.


### PR DESCRIPTION
## Summary
- fix outdated path in README and note run command

## Testing
- `python -m py_compile src/simulator.py`

------
https://chatgpt.com/codex/tasks/task_e_6878a16b34bc8322add614b8d2dd6afb