### PR TITLE
Add automated test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 This project is a small prototype for a feudal county simulation. The code
 is split across multiple modules under `src/`. Run the application with
 `python src/simulator.py`.
+
+## Testing
+Run `pytest` in the repository root to execute the automated test suite.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(BASE_DIR, "src"))
+sys.path.insert(0, BASE_DIR)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,111 @@
+import pytest
+
+from src import feodal_simulator as fs
+
+
+class DummySimulator(fs.FeodalSimulator):
+    """Minimal subclass that avoids GUI setup."""
+    def __init__(self):
+        # bypass parent __init__
+        pass
+
+def make_simulator(world_data):
+    sim = DummySimulator()
+    sim.world_data = world_data
+    sim._depth_cache = {}
+    # stub methods used in unit tests
+    sim.store_tree_state = lambda: (set(), ())
+    sim.populate_tree = lambda: None
+    sim.restore_tree_state = lambda *args, **kwargs: None
+    sim.show_node_view = lambda *args, **kwargs: None
+    sim.save_current_world = lambda: None
+    sim.add_status_message = lambda *args, **kwargs: None
+    sim.draw_static_border_lines = lambda: None
+    return sim
+
+
+def test_get_depth_of_node_and_cycles():
+    world = {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None},
+            "2": {"node_id": 2, "parent_id": 1},
+            "3": {"node_id": 3, "parent_id": 2},
+            "4": {"node_id": 4, "parent_id": 9},  # missing parent
+            "5": {"node_id": 5, "parent_id": 6},
+            "6": {"node_id": 6, "parent_id": 5},  # cycle
+        },
+        "characters": {},
+        "next_node_id": 6,
+    }
+    sim = make_simulator(world)
+    assert sim.get_depth_of_node(1) == 0
+    assert sim.get_depth_of_node(3) == 2
+    assert sim.get_depth_of_node(4) == 0  # orphan treated as depth 0
+    assert sim.get_depth_of_node(5) == -99  # cycle detected
+
+
+def test_get_display_name_for_node():
+    world = {
+        "nodes": {},
+        "characters": {"10": {"name": "Duke"}},
+        "next_node_id": 2,
+    }
+    sim = make_simulator(world)
+    # depth 1 with custom name
+    node = {"node_id": 2, "parent_id": 1, "name": "Furstendöme", "custom_name": "Uppland"}
+    assert sim.get_display_name_for_node(node, 1) == "Furstendöme [Uppland] (ID: 2)"
+    # depth 3 jarldom
+    node_j = {"node_id": 3, "custom_name": "Gotland"}
+    assert sim.get_display_name_for_node(node_j, 3) == "Gotland"
+    # depth 4 resource with ruler
+    node_r = {"node_id": 4, "res_type": "Bageri", "custom_name": "", "ruler_id": 10}
+    sim.world_data["characters"]["10"] = {"name": "Duke"}
+    assert sim.get_display_name_for_node(node_r, 4) == "Bageri - (Duke)"
+    # depth 4 with minimal data
+    node_r2 = {"node_id": 5}
+    assert sim.get_display_name_for_node(node_r2, 4) == "Resurs 5"
+
+
+def test_update_subfiefs_for_node_add_and_remove():
+    world = {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None, "name": "Kungarike", "children": [], "num_subfiefs": 0}
+        },
+        "characters": {},
+        "next_node_id": 1,
+    }
+    sim = make_simulator(world)
+    root = world["nodes"]["1"]
+    root["num_subfiefs"] = 2
+    sim.update_subfiefs_for_node(root)
+    assert len(root["children"]) == 2
+    assert set(root["children"]) == {2, 3}
+    assert world["nodes"]["2"]["parent_id"] == 1
+    # now reduce to one child
+    root["num_subfiefs"] = 1
+    sim.update_subfiefs_for_node(root)
+    assert len(root["children"]) == 1
+    assert root["children"][0] in {2, 3}
+    remaining_id = root["children"][0]
+    removed_id = 3 if remaining_id == 2 else 2
+    assert str(removed_id) not in world["nodes"]
+
+
+def test_attempt_link_neighbors_success():
+    world = {
+        "nodes": {
+            "10": {"node_id": 10, "parent_id": 1, "neighbors": [{"id": None, "border": fs.NEIGHBOR_NONE_STR} for _ in range(fs.MAX_NEIGHBORS)], "custom_name": "A"},
+            "20": {"node_id": 20, "parent_id": 1, "neighbors": [{"id": None, "border": fs.NEIGHBOR_NONE_STR} for _ in range(fs.MAX_NEIGHBORS)], "custom_name": "B"},
+        },
+        "characters": {},
+        "next_node_id": 20,
+    }
+    sim = make_simulator(world)
+    # Provide depth cache function result: treat both as depth 3
+    sim.get_depth_of_node = lambda nid: 3
+    messages = []
+    sim.add_status_message = lambda msg: messages.append(msg)
+    sim.attempt_link_neighbors(10, 20)
+    assert world["nodes"]["10"]["neighbors"][0]["id"] == 20
+    assert world["nodes"]["20"]["neighbors"][0]["id"] == 10
+    assert any("nu grannar" in m for m in messages)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,50 @@
+import random
+from src import utils
+
+
+def test_roll_dice_basic_deterministic():
+    random.seed(0)
+    value, dbg = utils.roll_dice("3d6")
+    assert value == 9
+    assert dbg == ""
+
+
+def test_roll_dice_constant_only():
+    random.seed(0)
+    value, _ = utils.roll_dice("+5")
+    assert value == 5
+
+
+def test_roll_dice_unlimited_exploding(monkeypatch):
+    seq = [6, 6, 2, 3]
+    iterator = iter(seq)
+
+    def fake_randint(a, b):
+        try:
+            return next(iterator)
+        except StopIteration:
+            return 1
+
+    monkeypatch.setattr(random, "randint", fake_randint)
+    value, dbg = utils.roll_dice("ob1d6", debug=True)
+    assert value == 6
+    assert "6->+2 nya" in dbg
+
+
+def test_generate_swedish_village_name_components():
+    random.seed(0)
+    name = utils.generate_swedish_village_name()
+    prefixes = [
+        "Björk", "Gran", "Lind", "Sjö", "Berg", "Älv", "Hav", "Hög", "Löv", "Ek",
+        "Sten", "Sol", "Vind", "Ask", "Rönn", "Klipp", "Dal", "Sand", "Ler", "Moss",
+        "Olof", "Erik", "Karl", "Ingrid", "Tor", "Frej", "Ulf", "Sig", "Arne", "Hilda",
+        "Sven", "Astrid", "Björn", "Helga", "Sten", "Siv", "Ragnar", "Estrid", "Håkan",
+        "Gunnar", "Liv", "Gertrud", "Bo", "Stig", "Svea", "Axel", "Alma",
+    ]
+    suffixes = [
+        "by", "torp", "hult", "ås", "rud", "forsa", "vik", "näs", "tuna", "stad",
+        "holm", "änge", "gård", "hed", "dal", "strand", "lid", "sjö", "träsk", "mark",
+        "hem", "lösa", "köping", "berga", "lunda", "måla", "ryd", "rum", "sta", "landa",
+    ]
+    assert any(name.startswith(p) for p in prefixes)
+    assert any(name.endswith(s) for s in suffixes)


### PR DESCRIPTION
## Summary
- add pytest configuration to include repository modules on the path
- create tests for utility helpers
- create tests for FeodalSimulator logic pieces
- document how to run tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ad74261883228140fa600055e334