### PR TITLE
Add Node dataclass

### DIFF
--- a/src/node.py
+++ b/src/node.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass, field
+from typing import List, Optional, Any
+
+from constants import MAX_NEIGHBORS, NEIGHBOR_NONE_STR
+
+
+@dataclass
+class Neighbor:
+    """Represents one neighbor connection for a node."""
+    id: Optional[int] = None
+    border: str = NEIGHBOR_NONE_STR
+
+
+@dataclass
+class Node:
+    """Simple object representation of a node in a world."""
+
+    node_id: int
+    parent_id: Optional[int]
+    name: str = ""
+    custom_name: str = ""
+    population: int = 0
+    ruler_id: Optional[int] = None
+    num_subfiefs: int = 0
+    children: List[int] = field(default_factory=list)
+    neighbors: List[Neighbor] = field(default_factory=list)
+    res_type: str = "Resurs"
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Node":
+        """Create a Node from a dictionary of raw world data."""
+        node_id = int(data.get("node_id"))
+        parent_id = data.get("parent_id")
+        if isinstance(parent_id, str) and parent_id.isdigit():
+            parent_id = int(parent_id)
+        elif parent_id is not None and not isinstance(parent_id, int):
+            parent_id = None
+
+        ruler_id = data.get("ruler_id")
+        if isinstance(ruler_id, str) and ruler_id.isdigit():
+            ruler_id = int(ruler_id)
+        elif ruler_id is not None and not isinstance(ruler_id, int):
+            ruler_id = None
+
+        children = [int(c) for c in data.get("children", []) if str(c).isdigit()]
+
+        # Normalise neighbor list to MAX_NEIGHBORS entries
+        neighbors_raw = data.get("neighbors", [])
+        neighbors: List[Neighbor] = []
+        for i in range(MAX_NEIGHBORS):
+            if i < len(neighbors_raw) and isinstance(neighbors_raw[i], dict):
+                ndata = neighbors_raw[i]
+                nid = ndata.get("id")
+                if isinstance(nid, str) and nid.isdigit():
+                    nid = int(nid)
+                border = ndata.get("border", NEIGHBOR_NONE_STR)
+                neighbors.append(Neighbor(nid, border))
+            else:
+                neighbors.append(Neighbor())
+
+        return cls(
+            node_id=node_id,
+            parent_id=parent_id,
+            name=data.get("name", ""),
+            custom_name=data.get("custom_name", ""),
+            population=int(data.get("population", 0)),
+            ruler_id=ruler_id,
+            num_subfiefs=int(data.get("num_subfiefs", 0)),
+            children=children,
+            neighbors=neighbors,
+            res_type=data.get("res_type", "Resurs"),
+        )

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,0 +1,29 @@
+from src.node import Node
+from src.constants import NEIGHBOR_NONE_STR, MAX_NEIGHBORS
+
+
+def test_node_from_dict_normalizes_fields():
+    raw = {
+        "node_id": 1,
+        "parent_id": None,
+        "name": "Kingdom",
+        "custom_name": "Svea",
+        "population": 100,
+        "ruler_id": "2",
+        "num_subfiefs": 0,
+        "children": ["2", 3],
+        "neighbors": [{"id": "2", "border": "v\u00e4g"}],
+        "res_type": "Resurs",
+    }
+
+    node = Node.from_dict(raw)
+
+    assert node.node_id == 1
+    assert node.parent_id is None
+    assert node.ruler_id == 2
+    assert node.children == [2, 3]
+    assert len(node.neighbors) == MAX_NEIGHBORS
+    assert node.neighbors[0].id == 2
+    assert node.neighbors[0].border == "v\u00e4g"
+    for nb in node.neighbors[1:]:
+        assert nb.id is None and nb.border == NEIGHBOR_NONE_STR


### PR DESCRIPTION
## Summary
- describe nodes with a dataclass in `src/node.py`
- test that `Node.from_dict()` correctly reads node dictionaries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a22679e6c8322affcca1146dd78d3