### PR TITLE
Add ownership label to node display names

### DIFF
--- a/src/world_manager.py
+++ b/src/world_manager.py
@@ -82,7 +82,7 @@ class WorldManager(WorldInterface):
         elif depth == 2:
             level_name = name or "Hertigdöme"
         elif depth == 3:
-            return f"{custom_name or f'Jarldöme {node_id}'}"
+            return f"{custom_name or f'Jarldöme {node_id}'} (ägande nod)"
         else:
             ruler_str = ""
             if ruler_id and "characters" in self.world_data:
@@ -97,14 +97,15 @@ class WorldManager(WorldInterface):
             if ruler_str:
                 parts.append(f"({ruler_str})")
             if not parts:
-                return f"Resurs {node_id}"
-            return " - ".join(parts)
+                return f"Resurs {node_id} (ägande nod)"
+            return " - ".join(parts) + " (ägande nod)"
 
         display = level_name
         if custom_name and custom_name != level_name:
             display += f" [{custom_name}]"
         if show_id:
             display += f" (ID: {node_id})"
+        display += " (ägande nod)"
         return display
 
     def update_subfiefs_for_node(self, node_data: Dict[str, Any]) -> None:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -53,17 +53,17 @@ def test_get_display_name_for_node():
     sim = make_simulator(world)
     # depth 1 with custom name
     node = {"node_id": 2, "parent_id": 1, "name": "Furstendöme", "custom_name": "Uppland"}
-    assert sim.get_display_name_for_node(node, 1) == "Furstendöme [Uppland] (ID: 2)"
+    assert sim.get_display_name_for_node(node, 1) == "Furstendöme [Uppland] (ID: 2) (ägande nod)"
     # depth 3 jarldom
     node_j = {"node_id": 3, "custom_name": "Gotland"}
-    assert sim.get_display_name_for_node(node_j, 3) == "Gotland"
+    assert sim.get_display_name_for_node(node_j, 3) == "Gotland (ägande nod)"
     # depth 4 resource with ruler
     node_r = {"node_id": 4, "res_type": "Bageri", "custom_name": "", "ruler_id": 10}
     sim.world_data["characters"]["10"] = {"name": "Duke"}
-    assert sim.get_display_name_for_node(node_r, 4) == "Bageri - (Duke)"
+    assert sim.get_display_name_for_node(node_r, 4) == "Bageri - (Duke) (ägande nod)"
     # depth 4 with minimal data
     node_r2 = {"node_id": 5}
-    assert sim.get_display_name_for_node(node_r2, 4) == "Resurs 5"
+    assert sim.get_display_name_for_node(node_r2, 4) == "Resurs 5 (ägande nod)"
 
 
 def test_update_subfiefs_for_node_add_and_remove():


### PR DESCRIPTION
## Summary
- append `(ägande nod)` to all node names
- update tests to expect the new display format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d24ca71e8832eafc2e982fe151692