### PR TITLE
Highlight sibling nodes when linking

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -1732,7 +1732,11 @@ class FeodalSimulator:
                     self.static_map_canvas.itemconfig(tag, fill="#ccffcc", outline="green")
 
     def highlight_neighbor_candidates(self, start_node_id):
-        """Highlights potential neighbors when starting a link drag."""
+        """Highlights potential neighbors when starting a link drag.
+
+        Nodes that share the same parent as ``start_node_id`` are colored yellow
+        while existing neighbors are highlighted in red.
+        """
         if not self.static_map_canvas or not self.world_data:
             return
         self.reset_hex_highlights()
@@ -1761,7 +1765,10 @@ class FeodalSimulator:
             pos = self.map_static_positions.get(sid)
             if pos:
                 r, c = pos
-                self.static_map_canvas.itemconfig(f"hex_{r}_{c}", fill="#aaffaa", outline="green")
+                # Yellow highlight for nodes sharing the same parent
+                self.static_map_canvas.itemconfig(
+                    f"hex_{r}_{c}", fill="#ffffaa", outline="green"
+                )
 
         for nid in neighbor_ids:
             pos = self.map_static_positions.get(nid)


### PR DESCRIPTION
## Summary
- tweak highlight colors in `highlight_neighbor_candidates`
- update docstring to explain color meaning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d297837fc832ebca9867d1ac9c987