### PR TITLE
Show owning node name in display

### DIFF
--- a/src/world_manager.py
+++ b/src/world_manager.py
@@ -75,6 +75,17 @@ class WorldManager(WorldInterface):
 
         level_name = ""
         show_id = True
+        parent_name: str | None = None
+        parent_id = None
+        if isinstance(node_data, Node):
+            parent_id = node_data.parent_id
+        else:
+            parent_id = node_data.get("parent_id")
+        if parent_id is not None:
+            parent = self.world_data.get("nodes", {}).get(str(parent_id))
+            if parent:
+                parent_custom = str(parent.get("custom_name", "")).strip()
+                parent_name = parent_custom or parent.get("name") or f"Nod {parent_id}"
         if depth == 0:
             level_name = name or "Kungarike"
         elif depth == 1:
@@ -82,7 +93,8 @@ class WorldManager(WorldInterface):
         elif depth == 2:
             level_name = name or "Hertigdöme"
         elif depth == 3:
-            return f"{custom_name or f'Jarldöme {node_id}'} (ägande nod)"
+            owner_suffix = f" ({parent_name})" if parent_name else ""
+            return f"{custom_name or f'Jarldöme {node_id}'}{owner_suffix}"
         else:
             ruler_str = ""
             if ruler_id and "characters" in self.world_data:
@@ -97,15 +109,18 @@ class WorldManager(WorldInterface):
             if ruler_str:
                 parts.append(f"({ruler_str})")
             if not parts:
-                return f"Resurs {node_id} (ägande nod)"
-            return " - ".join(parts) + " (ägande nod)"
+                owner_suffix = f" ({parent_name})" if parent_name else ""
+                return f"Resurs {node_id}{owner_suffix}"
+            owner_suffix = f" ({parent_name})" if parent_name else ""
+            return " - ".join(parts) + owner_suffix
 
         display = level_name
         if custom_name and custom_name != level_name:
             display += f" [{custom_name}]"
         if show_id:
             display += f" (ID: {node_id})"
-        display += " (ägande nod)"
+        if parent_name:
+            display += f" ({parent_name})"
         return display
 
     def update_subfiefs_for_node(self, node_data: Dict[str, Any]) -> None:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -46,24 +46,29 @@ def test_get_depth_of_node_and_cycles():
 
 def test_get_display_name_for_node():
     world = {
-        "nodes": {},
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None, "name": "Kungarike"},
+            "2": {"node_id": 2, "parent_id": 1, "name": "Furstendöme", "custom_name": "Uppland"},
+            "3": {"node_id": 3, "parent_id": 2, "custom_name": "Gotland"},
+            "4": {"node_id": 4, "parent_id": 3, "res_type": "Bageri", "custom_name": "", "ruler_id": 10},
+            "5": {"node_id": 5, "parent_id": 3},
+        },
         "characters": {"10": {"name": "Duke"}},
-        "next_node_id": 2,
+        "next_node_id": 6,
     }
     sim = make_simulator(world)
     # depth 1 with custom name
-    node = {"node_id": 2, "parent_id": 1, "name": "Furstendöme", "custom_name": "Uppland"}
-    assert sim.get_display_name_for_node(node, 1) == "Furstendöme [Uppland] (ID: 2) (ägande nod)"
+    node = world["nodes"]["2"]
+    assert sim.get_display_name_for_node(node, 1) == "Furstendöme [Uppland] (ID: 2) (Kungarike)"
     # depth 3 jarldom
-    node_j = {"node_id": 3, "custom_name": "Gotland"}
-    assert sim.get_display_name_for_node(node_j, 3) == "Gotland (ägande nod)"
+    node_j = world["nodes"]["3"]
+    assert sim.get_display_name_for_node(node_j, 3) == "Gotland (Uppland)"
     # depth 4 resource with ruler
-    node_r = {"node_id": 4, "res_type": "Bageri", "custom_name": "", "ruler_id": 10}
-    sim.world_data["characters"]["10"] = {"name": "Duke"}
-    assert sim.get_display_name_for_node(node_r, 4) == "Bageri - (Duke) (ägande nod)"
+    node_r = world["nodes"]["4"]
+    assert sim.get_display_name_for_node(node_r, 4) == "Bageri - (Duke) (Gotland)"
     # depth 4 with minimal data
-    node_r2 = {"node_id": 5}
-    assert sim.get_display_name_for_node(node_r2, 4) == "Resurs 5 (ägande nod)"
+    node_r2 = world["nodes"]["5"]
+    assert sim.get_display_name_for_node(node_r2, 4) == "Resurs 5 (Gotland)"
 
 
 def test_update_subfiefs_for_node_add_and_remove():


### PR DESCRIPTION
## Summary
- update `WorldManager.get_display_name_for_node` to show the parent node name
- adjust unit tests for the new display format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2c2ea6e4832eaa14427f478690ae