### PR TITLE
Add directional neighbor logic

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -1767,7 +1767,18 @@ class FeodalSimulator:
 
     def attempt_link_neighbors(self, node_id1, node_id2):
         """Attempts to link two Jarldoms as neighbors."""
-        success, message = self.world_manager.attempt_link_neighbors(node_id1, node_id2)
+        slot = None
+        if (
+            getattr(self, "map_logic", None)
+            and node_id1 in getattr(self, "map_static_positions", {})
+            and node_id2 in getattr(self, "map_static_positions", {})
+        ):
+            r1, c1 = self.map_static_positions[node_id1]
+            r2, c2 = self.map_static_positions[node_id2]
+            slot = self.map_logic.direction_index(r1, c1, r2, c2)
+        success, message = self.world_manager.attempt_link_neighbors(
+            node_id1, node_id2, slot1=slot
+        )
         if success:
             self.save_current_world()
             self.draw_static_border_lines()

--- a/tests/test_map_logic.py
+++ b/tests/test_map_logic.py
@@ -1,13 +1,19 @@
 import math
 from src.map_logic import StaticMapLogic
+from src.constants import NEIGHBOR_NONE_STR, MAX_NEIGHBORS
 
 
 def make_world():
+    empty = [{"id": None, "border": NEIGHBOR_NONE_STR} for _ in range(MAX_NEIGHBORS)]
+    n10 = empty.copy()
+    n20 = empty.copy()
+    n10[3] = {"id": 20, "border": "v\u00e4g"}
+    n20[0] = {"id": 10, "border": "v\u00e4g"}
     return {
         "nodes": {
-            "10": {"node_id": 10, "neighbors": [{"id": 20, "border": "v\u00e4g"}]},
-            "20": {"node_id": 20, "neighbors": [{"id": 10, "border": "v\u00e4g"}]},
-            "30": {"node_id": 30, "neighbors": []},
+            "10": {"node_id": 10, "neighbors": n10},
+            "20": {"node_id": 20, "neighbors": n20},
+            "30": {"node_id": 30, "neighbors": empty.copy()},
         },
         "characters": {},
     }
@@ -46,9 +52,9 @@ def test_placement_and_border_lines():
     assert color == "peru"
     assert width == 2
 
-    cx10, cy10 = logic.hex_center(*logic.map_static_positions[10])
-    cx20, cy20 = logic.hex_center(*logic.map_static_positions[20])
-    assert math.isclose(x1, cx10)
-    assert math.isclose(y1, cy10)
-    assert math.isclose(x2, cx20)
-    assert math.isclose(y2, cy20)
+    start = logic.hex_side_center(*logic.map_static_positions[10], 4)
+    end = logic.hex_side_center(*logic.map_static_positions[20], 1)
+    assert math.isclose(x1, start[0])
+    assert math.isclose(y1, start[1])
+    assert math.isclose(x2, end[0])
+    assert math.isclose(y2, end[1])

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -1,0 +1,19 @@
+from src.world_manager import WorldManager
+from src.constants import MAX_NEIGHBORS, NEIGHBOR_NONE_STR
+
+
+def test_attempt_link_neighbors_directional():
+    world = {
+        "nodes": {
+            "10": {"node_id": 10, "parent_id": 1, "neighbors": [{"id": None, "border": NEIGHBOR_NONE_STR} for _ in range(MAX_NEIGHBORS)]},
+            "20": {"node_id": 20, "parent_id": 1, "neighbors": [{"id": None, "border": NEIGHBOR_NONE_STR} for _ in range(MAX_NEIGHBORS)]},
+        },
+        "characters": {},
+    }
+    manager = WorldManager(world)
+    manager.get_depth_of_node = lambda _nid: 3
+
+    ok, _ = manager.attempt_link_neighbors(10, 20, slot1=2)
+    assert ok
+    assert world["nodes"]["10"]["neighbors"][1]["id"] == 20
+    assert world["nodes"]["20"]["neighbors"][4]["id"] == 10


### PR DESCRIPTION
## Summary
- support directional hex neighbours and track opposite slots
- compute direction indices for static map rendering
- update neighbour linking logic to honor slot orientation
- adjust static map tests
- add world manager tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ddde74b888322b6264bbaa7750f46