### PR TITLE
Add scrollable frames for node editors

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -18,7 +18,7 @@ from constants import (
 )
 from data_manager import load_worlds_from_file, save_worlds_to_file
 from node import Node
-from utils import roll_dice, generate_swedish_village_name
+from utils import roll_dice, generate_swedish_village_name, ScrollableFrame
 from dynamic_map import DynamicMapCanvas
 from map_logic import StaticMapLogic
 from world_manager import WorldManager
@@ -918,7 +918,6 @@ class FeodalSimulator:
         # --- Main container frame with padding ---
         view_frame = ttk.Frame(self.right_frame, padding="10 10 10 10")
         view_frame.pack(fill="both", expand=True)
-        # Allow content to expand
         view_frame.grid_rowconfigure(1, weight=1)
         view_frame.grid_columnconfigure(0, weight=1)
 
@@ -929,9 +928,10 @@ class FeodalSimulator:
         title_label.pack(side=tk.LEFT)
         ttk.Label(title_frame, text=f" (ID: {node_id}, Djup: {depth})", font=("Arial", 10)).pack(side=tk.LEFT, anchor="s", padx=5)
 
-        # --- Frame for the actual editor content ---
-        editor_content_frame = ttk.Frame(view_frame)
-        editor_content_frame.pack(fill="both", expand=True)
+        # --- Scrollable area for editor content ---
+        scroll_frame = ScrollableFrame(view_frame)
+        scroll_frame.pack(fill="both", expand=True)
+        editor_content_frame = scroll_frame.content
 
 
         # --- Call specific editor based on depth ---
@@ -1563,8 +1563,9 @@ class FeodalSimulator:
         custom_name = node_data.get("custom_name", f"Jarldom {node_id}")
 
         # --- Main container frame ---
-        view_frame = ttk.Frame(self.right_frame, padding="10 10 10 10")
-        view_frame.pack(fill="both", expand=True)
+        scroll_view = ScrollableFrame(self.right_frame, padding="10 10 10 10")
+        scroll_view.pack(fill="both", expand=True)
+        view_frame = scroll_view.content
 
         ttk.Label(view_frame, text=f"Redigera Grannar för: {custom_name}", font=("Arial", 14)).pack(pady=(0, 15))
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,7 @@
 """Utility functions used by the simulator."""
 import random
+import tkinter as tk
+from tkinter import ttk
 
 
 def roll_dice(expr: str, debug=False):
@@ -93,3 +95,37 @@ def generate_swedish_village_name():
         "hem", "lösa", "köping", "berga", "lunda", "måla", "ryd", "rum", "sta", "landa",
     ]
     return random.choice(FORLEDER) + random.choice(EFTERLEDER)
+
+
+class ScrollableFrame(ttk.Frame):
+    """A frame that adds a vertical scrollbar when content overflows."""
+
+    def __init__(self, parent, *args, **kwargs):
+        super().__init__(parent, *args, **kwargs)
+        self.canvas = tk.Canvas(self, borderwidth=0, highlightthickness=0)
+        self.vscroll = ttk.Scrollbar(self, orient="vertical", command=self.canvas.yview)
+        self.canvas.configure(yscrollcommand=self.vscroll.set)
+
+        self.content = ttk.Frame(self.canvas)
+        self.content.bind("<Configure>", self._on_frame_configure)
+        self.canvas.bind("<Configure>", self._on_canvas_configure)
+        self.canvas.create_window((0, 0), window=self.content, anchor="nw")
+
+        self.canvas.pack(side=tk.LEFT, fill="both", expand=True)
+        self.vscroll.pack(side=tk.RIGHT, fill="y")
+        self._update_scrollbar()
+
+    def _on_frame_configure(self, event=None):
+        self.canvas.configure(scrollregion=self.canvas.bbox("all"))
+        self._update_scrollbar()
+
+    def _on_canvas_configure(self, event=None):
+        self._update_scrollbar()
+
+    def _update_scrollbar(self):
+        if self.content.winfo_height() > self.canvas.winfo_height():
+            if not self.vscroll.winfo_ismapped():
+                self.vscroll.pack(side=tk.RIGHT, fill="y")
+        else:
+            if self.vscroll.winfo_ismapped():
+                self.vscroll.pack_forget()


### PR DESCRIPTION
## Summary
- provide `ScrollableFrame` helper to auto-enable vertical scrolling
- use `ScrollableFrame` in node editor and neighbor editor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dfecc5a4c832ebe379739524955de