### PR TITLE
Compute node population from categories

### DIFF
--- a/src/node.py
+++ b/src/node.py
@@ -69,6 +69,12 @@ class Node:
         unfree_peasants = int(data.get("unfree_peasants", 0) or 0)
         thralls = int(data.get("thralls", 0) or 0)
         burghers = int(data.get("burghers", 0) or 0)
+        base_pop = int(data.get("population", 0) or 0)
+        computed_pop = free_peasants + unfree_peasants + thralls + burghers
+        if computed_pop:
+            population = computed_pop
+        else:
+            population = base_pop
         craftsmen_raw = data.get("craftsmen", [])
         craftsmen: List[dict] = []
         if isinstance(craftsmen_raw, list):
@@ -88,7 +94,7 @@ class Node:
             parent_id=parent_id,
             name=data.get("name", ""),
             custom_name=data.get("custom_name", ""),
-            population=int(data.get("population", 0)),
+            population=population,
             ruler_id=ruler_id,
             num_subfiefs=int(data.get("num_subfiefs", 0)),
             children=children,
@@ -109,7 +115,7 @@ class Node:
             "parent_id": self.parent_id,
             "name": self.name,
             "custom_name": self.custom_name,
-            "population": self.population,
+            "population": self.calculate_population(),
             "ruler_id": self.ruler_id,
             "num_subfiefs": self.num_subfiefs,
             "children": list(self.children),
@@ -127,3 +133,13 @@ class Node:
                 for c in self.craftsmen
             ],
         }
+
+    def calculate_population(self) -> int:
+        """Return the total population for this node based on categories."""
+        total = (
+            self.free_peasants
+            + self.unfree_peasants
+            + self.thralls
+            + self.burghers
+        )
+        return total if total else self.population

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -72,3 +72,18 @@ def test_node_settlement_roundtrip():
         {"type": "Smed", "count": 3},
         {"type": "Bagare", "count": 1},
     ]
+
+
+def test_node_population_calculated_from_categories():
+    raw = {
+        "node_id": 8,
+        "parent_id": 1,
+        "free_peasants": 3,
+        "unfree_peasants": 2,
+        "thralls": 1,
+        "burghers": 4,
+    }
+    node = Node.from_dict(raw)
+    assert node.population == 10
+    data = node.to_dict()
+    assert data["population"] == 10


### PR DESCRIPTION
## Summary
- compute `population` from peasants, thralls and burghers in `Node`
- expose `Node.calculate_population`
- display computed population in simulator editors
- ensure resource updates recalc population
- add regression tests for new calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e031d3d44832e949ebf4b154e3520