### PR TITLE
Add resource aggregation support

### DIFF
--- a/src/node.py
+++ b/src/node.py
@@ -31,6 +31,10 @@ class Node:
     thralls: int = 0
     burghers: int = 0
     craftsmen: List[dict] = field(default_factory=list)
+    soldiers: List[dict] = field(default_factory=list)
+    characters: List[dict] = field(default_factory=list)
+    animals: List[dict] = field(default_factory=list)
+    buildings: List[dict] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: dict) -> "Node":
@@ -89,6 +93,35 @@ class Node:
                     count_int = 1
                 craftsmen.append({"type": str(ctype), "count": max(1, min(count_int, 9))})
 
+        def parse_list_of_dict(key: str, count_field: bool = False) -> List[dict]:
+            items_raw = data.get(key, [])
+            items: List[dict] = []
+            if isinstance(items_raw, list):
+                for entry in items_raw:
+                    if not isinstance(entry, dict):
+                        continue
+                    tval = entry.get("type", "")
+                    if count_field:
+                        count = entry.get("count", 1)
+                        try:
+                            cnt = int(count)
+                        except (ValueError, TypeError):
+                            cnt = 1
+                        items.append({"type": str(tval), "count": max(0, cnt)})
+                    else:
+                        rid = entry.get("ruler_id")
+                        if isinstance(rid, str) and rid.isdigit():
+                            rid = int(rid)
+                        elif rid is not None and not isinstance(rid, int):
+                            rid = None
+                        items.append({"type": str(tval), "ruler_id": rid})
+            return items
+
+        soldiers = parse_list_of_dict("soldiers", count_field=True)
+        characters = parse_list_of_dict("characters", count_field=False)
+        animals = parse_list_of_dict("animals", count_field=True)
+        buildings = parse_list_of_dict("buildings", count_field=True)
+
         return cls(
             node_id=node_id,
             parent_id=parent_id,
@@ -106,6 +139,10 @@ class Node:
             thralls=thralls,
             burghers=burghers,
             craftsmen=craftsmen,
+            soldiers=soldiers,
+            characters=characters,
+            animals=animals,
+            buildings=buildings,
         )
 
     def to_dict(self) -> dict:
@@ -131,6 +168,22 @@ class Node:
             "craftsmen": [
                 {"type": c.get("type", ""), "count": c.get("count", 1)}
                 for c in self.craftsmen
+            ],
+            "soldiers": [
+                {"type": s.get("type", ""), "count": s.get("count", 1)}
+                for s in self.soldiers
+            ],
+            "characters": [
+                {"type": c.get("type", ""), "ruler_id": c.get("ruler_id")}
+                for c in self.characters
+            ],
+            "animals": [
+                {"type": a.get("type", ""), "count": a.get("count", 1)}
+                for a in self.animals
+            ],
+            "buildings": [
+                {"type": b.get("type", ""), "count": b.get("count", 1)}
+                for b in self.buildings
             ],
         }
 

--- a/src/world_interface.py
+++ b/src/world_interface.py
@@ -149,6 +149,10 @@ class WorldInterface(ABC):
                 if "res_type" not in node:
                     node["res_type"] = "Resurs"
                     updated = True
+                for key in ("soldiers", "characters", "animals", "buildings"):
+                    if key not in node or not isinstance(node[key], list):
+                        node[key] = []
+                        updated = True
 
             if updated:
                 nodes_updated += 1

--- a/src/world_manager.py
+++ b/src/world_manager.py
@@ -23,6 +23,55 @@ class WorldManager(WorldInterface):
     def clear_depth_cache(self) -> None:
         self._depth_cache = {}
 
+    def aggregate_resources(self, node_id: int) -> Dict[str, Dict[str, int]]:
+        """Return aggregated resource counts for ``node_id`` and descendants."""
+
+        totals = {"soldiers": {}, "characters": {}, "animals": {}, "buildings": {}}
+        nodes = self.world_data.get("nodes", {})
+
+        def add_count(target: Dict[str, int], key: str, amount: int = 1) -> None:
+            if not key:
+                return
+            target[key] = target.get(key, 0) + amount
+
+        def recurse(nid: int) -> None:
+            node = nodes.get(str(nid))
+            if not node:
+                return
+            for entry in node.get("soldiers", []):
+                t = entry.get("type")
+                c = entry.get("count", 0)
+                try:
+                    c = int(c)
+                except (ValueError, TypeError):
+                    c = 0
+                add_count(totals["soldiers"], t, c)
+            for entry in node.get("characters", []):
+                t = entry.get("type")
+                add_count(totals["characters"], t, 1)
+            for entry in node.get("animals", []):
+                t = entry.get("type")
+                c = entry.get("count", 0)
+                try:
+                    c = int(c)
+                except (ValueError, TypeError):
+                    c = 0
+                add_count(totals["animals"], t, c)
+            for entry in node.get("buildings", []):
+                t = entry.get("type")
+                c = entry.get("count", 0)
+                try:
+                    c = int(c)
+                except (ValueError, TypeError):
+                    c = 0
+                add_count(totals["buildings"], t, c)
+
+            for child in node.get("children", []):
+                recurse(child)
+
+        recurse(node_id)
+        return totals
+
     # -------------------------------------------
     # WorldInterface implementation
     # -------------------------------------------

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -87,3 +87,25 @@ def test_node_population_calculated_from_categories():
     assert node.population == 10
     data = node.to_dict()
     assert data["population"] == 10
+
+
+def test_node_extra_resource_roundtrip():
+    raw = {
+        "node_id": 20,
+        "parent_id": 1,
+        "soldiers": [{"type": "B\u00e5gskytt", "count": "2"}],
+        "characters": [{"type": "Officer", "ruler_id": "5"}],
+        "animals": [{"type": "Oxe", "count": 3}],
+        "buildings": [{"type": "Smedja", "count": "1"}],
+    }
+    node = Node.from_dict(raw)
+    assert node.soldiers == [{"type": "B\u00e5gskytt", "count": 2}]
+    assert node.characters == [{"type": "Officer", "ruler_id": 5}]
+    assert node.animals == [{"type": "Oxe", "count": 3}]
+    assert node.buildings == [{"type": "Smedja", "count": 1}]
+
+    back = node.to_dict()
+    assert back["soldiers"] == [{"type": "B\u00e5gskytt", "count": 2}]
+    assert back["characters"] == [{"type": "Officer", "ruler_id": 5}]
+    assert back["animals"] == [{"type": "Oxe", "count": 3}]
+    assert back["buildings"] == [{"type": "Smedja", "count": 1}]

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -17,3 +17,33 @@ def test_attempt_link_neighbors_directional():
     assert ok
     assert world["nodes"]["10"]["neighbors"][1]["id"] == 20
     assert world["nodes"]["20"]["neighbors"][4]["id"] == 10
+
+
+def test_aggregate_resources_simple():
+    world = {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None, "children": [2, 3]},
+            "2": {
+                "node_id": 2,
+                "parent_id": 1,
+                "children": [],
+                "soldiers": [{"type": "B\u00e5gskytt", "count": 2}],
+                "animals": [{"type": "Oxe", "count": 1}],
+            },
+            "3": {
+                "node_id": 3,
+                "parent_id": 1,
+                "children": [],
+                "soldiers": [
+                    {"type": "B\u00e5gskytt", "count": 1},
+                    {"type": "Fotsoldat", "count": 3},
+                ],
+            },
+        },
+        "characters": {},
+    }
+    manager = WorldManager(world)
+    totals = manager.aggregate_resources(1)
+    assert totals["soldiers"]["B\u00e5gskytt"] == 3
+    assert totals["soldiers"]["Fotsoldat"] == 3
+    assert totals["animals"]["Oxe"] == 1


### PR DESCRIPTION
## Summary
- extend `Node` with soldiers, characters, animals and buildings lists
- add resource aggregation to `WorldManager`
- validate new lists in `WorldInterface`
- test round-trip for extra resources
- test aggregation of resources

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e08c633c0832e8afe2ae07d8ef1d6