### PR TITLE
Add descendant counting utility

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -998,7 +998,7 @@ class FeodalSimulator:
                 confirm_msg += "\n\nObservera: Noden har osparade ändringar." 
             num_children = len(node_data.get("children", []))
             # Estimate total descendants for better warning
-            descendant_count = self.count_descendants(node_id)
+            descendant_count = self.world_manager.count_descendants(node_id)
 
             if descendant_count > 0:
                 confirm_msg += f"\n\nVARNING: Detta kommer även att radera {descendant_count} underliggande förläning(ar)!"

--- a/src/world_manager.py
+++ b/src/world_manager.py
@@ -320,6 +320,26 @@ class WorldManager(WorldInterface):
             del self.world_data["nodes"][node_id_str]
         return deleted_count
 
+    def count_descendants(self, node_id: int) -> int:
+        """Return the total number of descendant nodes for ``node_id``."""
+        nodes = self.world_data.get("nodes", {})
+        visited: set[int] = set()
+
+        def recurse(nid: int) -> int:
+            if nid in visited:
+                return 0
+            visited.add(nid)
+            node = nodes.get(str(nid))
+            if not node:
+                return 0
+            total = 0
+            for child in node.get("children", []):
+                total += 1
+                total += recurse(child)
+            return total
+
+        return recurse(node_id)
+
     def attempt_link_neighbors(
         self,
         node_id1: int,

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -85,3 +85,21 @@ def test_calculate_total_resources_recursive():
     assert totals["soldiers"]["Archer"] == 3
     assert world["nodes"]["2"]["total_resources"]["population"] == 7
     assert world["nodes"]["4"]["total_resources"]["population"] == 2
+
+
+def test_count_descendants_simple_hierarchy():
+    world = {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None, "children": [2, 3]},
+            "2": {"node_id": 2, "parent_id": 1, "children": [4]},
+            "3": {"node_id": 3, "parent_id": 1, "children": []},
+            "4": {"node_id": 4, "parent_id": 2, "children": []},
+        },
+        "characters": {},
+    }
+
+    manager = WorldManager(world)
+
+    assert manager.count_descendants(1) == 3
+    assert manager.count_descendants(2) == 1
+    assert manager.count_descendants(3) == 0


### PR DESCRIPTION
## Summary
- implement `count_descendants` in `WorldManager`
- use the new method in the delete-node confirmation logic
- test `count_descendants` with a simple hierarchy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e31c77ed4832e90a660377ea1bc3f