### PR TITLE
Add tunnland field for Vildmark resources

### DIFF
--- a/src/node.py
+++ b/src/node.py
@@ -30,6 +30,7 @@ class Node:
     unfree_peasants: int = 0
     thralls: int = 0
     burghers: int = 0
+    tunnland: int = 0  # Area for wilderness resources measured in tunnland
     craftsmen: List[dict] = field(default_factory=list)
     soldiers: List[dict] = field(default_factory=list)
     characters: List[dict] = field(default_factory=list)
@@ -73,9 +74,13 @@ class Node:
         unfree_peasants = int(data.get("unfree_peasants", 0) or 0)
         thralls = int(data.get("thralls", 0) or 0)
         burghers = int(data.get("burghers", 0) or 0)
+        tunnland = int(data.get("tunnland", 0) or 0)
         base_pop = int(data.get("population", 0) or 0)
         computed_pop = free_peasants + unfree_peasants + thralls + burghers
-        if computed_pop:
+        res_type = data.get("res_type", "Resurs")
+        if res_type == "Vildmark":
+            population = 0
+        elif computed_pop:
             population = computed_pop
         else:
             population = base_pop
@@ -132,12 +137,13 @@ class Node:
             num_subfiefs=int(data.get("num_subfiefs", 0)),
             children=children,
             neighbors=neighbors,
-            res_type=data.get("res_type", "Resurs"),
+            res_type=res_type,
             settlement_type=settlement_type,
             free_peasants=free_peasants,
             unfree_peasants=unfree_peasants,
             thralls=thralls,
             burghers=burghers,
+            tunnland=tunnland,
             craftsmen=craftsmen,
             soldiers=soldiers,
             characters=characters,
@@ -165,6 +171,7 @@ class Node:
             "unfree_peasants": self.unfree_peasants,
             "thralls": self.thralls,
             "burghers": self.burghers,
+            "tunnland": self.tunnland,
             "craftsmen": [
                 {"type": c.get("type", ""), "count": c.get("count", 1)}
                 for c in self.craftsmen

--- a/src/world_interface.py
+++ b/src/world_interface.py
@@ -107,9 +107,14 @@ class WorldInterface(ABC):
             if "children" not in node:
                 node["children"] = []
                 updated = True
-            if "population" not in node:
-                node["population"] = 0
-                updated = True
+            if node.get("res_type") == "Vildmark":
+                if "tunnland" not in node:
+                    node["tunnland"] = 0
+                    updated = True
+            else:
+                if "population" not in node:
+                    node["population"] = 0
+                    updated = True
 
             node["children"] = [int(c) for c in node.get("children", []) if str(c).isdigit()]
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -109,3 +109,20 @@ def test_node_extra_resource_roundtrip():
     assert back["characters"] == [{"type": "Officer", "ruler_id": 5}]
     assert back["animals"] == [{"type": "Oxe", "count": 3}]
     assert back["buildings"] == [{"type": "Smedja", "count": 1}]
+
+
+def test_node_vildmark_tunnland_roundtrip():
+    raw = {
+        "node_id": 40,
+        "parent_id": 1,
+        "res_type": "Vildmark",
+        "tunnland": 7,
+    }
+
+    node = Node.from_dict(raw)
+    assert node.tunnland == 7
+    assert node.population == 0
+
+    back = node.to_dict()
+    assert back["tunnland"] == 7
+    assert back["population"] == 0

--- a/tests/test_world_interface.py
+++ b/tests/test_world_interface.py
@@ -87,6 +87,26 @@ def test_validate_world_data_basic():
     assert world["characters"]["10"]["char_id"] == 10
 
 
+def test_validate_world_data_vildmark_defaults():
+    world = {
+        "nodes": {
+            "1": {
+                "node_id": 1,
+                "parent_id": None,
+                "res_type": "Vildmark",
+            }
+        },
+        "characters": {},
+    }
+    manager = WorldManager(world)
+    manager.get_depth_of_node = lambda _nid: 4
+    nodes_updated, _ = manager.validate_world_data()
+    assert nodes_updated > 0
+    node = world["nodes"]["1"]
+    assert "tunnland" in node
+    assert "population" not in node
+
+
 def test_update_neighbors_for_node_bidirectional():
     world = {
         "nodes": {


### PR DESCRIPTION
## Summary
- add `tunnland` attribute on `Node` for wilderness area
- treat Vildmark nodes specially in `validate_world_data`
- support tunnland in node serialization
- test roundtrip handling and validation defaults for Vildmark

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e3537d050832eaea57420e6abdcbd