### PR TITLE
Fix jarldome editor variable

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -1376,26 +1376,6 @@ class FeodalSimulator:
         pop_entry = ttk.Entry(editor_frame, textvariable=pop_var, width=10)
         pop_entry.grid(row=row_idx, column=1, sticky="w", padx=5, pady=3)
 
-        area_label = ttk.Label(editor_frame, text="Tunnland:")
-        area_var = tk.IntVar(value=node_data.get("tunnland", 0))
-        area_entry = ttk.Entry(editor_frame, textvariable=area_var, width=10)
-        area_label.grid(row=row_idx, column=0, sticky="w", padx=5, pady=3)
-        area_entry.grid(row=row_idx, column=1, sticky="w", padx=5, pady=3)
-
-        def refresh_area_visibility(*_):
-            if res_var.get() == "Vildmark":
-                pop_label.grid_remove()
-                pop_entry.grid_remove()
-                area_label.grid()
-                area_entry.grid()
-            else:
-                area_label.grid_remove()
-                area_entry.grid_remove()
-                pop_label.grid()
-                pop_entry.grid()
-
-        res_var.trace_add("write", refresh_area_visibility)
-        refresh_area_visibility()
         row_idx += 1
 
         # Number of Subfiefs (Resources under the Jarldom)


### PR DESCRIPTION
## Summary
- remove dead code referencing res_var in jarldome editor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f0cf27160832e8eaad6fbd4fb9f60