### PR TITLE
Implement hierarchical population updates

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -1283,6 +1283,7 @@ class FeodalSimulator:
                 status_details.append(f"Befolkning: {old_pop} -> {new_pop}")
 
             if changes_made:
+                self.world_manager.update_population_totals()
                 self.save_current_world()
                 status = f"Nod {node_id} uppdaterad: " + ", ".join(status_details)
                 self.add_status_message(status)
@@ -1440,6 +1441,7 @@ class FeodalSimulator:
             node_data["res_type"] = "Resurs" # Ensure internal type
 
             if changes_made:
+                self.world_manager.update_population_totals()
                 self.save_current_world()
                 status = f"Jarldöme {node_id} uppdaterad: " + ", ".join(status_details)
                 self.add_status_message(status)
@@ -1822,6 +1824,7 @@ class FeodalSimulator:
                 changes = True
 
             if changes:
+                self.world_manager.update_population_totals()
                 self.save_current_world()
                 status = f"Resurs {node_id} uppdaterad: " + ", ".join(details)
                 self.add_status_message(status)

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -103,3 +103,25 @@ def test_count_descendants_simple_hierarchy():
     assert manager.count_descendants(1) == 3
     assert manager.count_descendants(2) == 1
     assert manager.count_descendants(3) == 0
+
+
+def test_update_population_totals_bottom_up():
+    world = {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None, "children": [2]},
+            "2": {"node_id": 2, "parent_id": 1, "children": [3], "population": 1},
+            "3": {"node_id": 3, "parent_id": 2, "children": [4, 5]},
+            "4": {"node_id": 4, "parent_id": 3, "children": [], "population": 4},
+            "5": {"node_id": 5, "parent_id": 3, "children": [], "free_peasants": 2},
+        },
+        "characters": {},
+    }
+
+    manager = WorldManager(world)
+    manager.get_depth_of_node = lambda nid: {1: 0, 2: 1, 3: 2, 4: 3, 5: 3}[nid]
+    manager.update_population_totals()
+
+    assert world["nodes"]["5"]["population"] == 2
+    assert world["nodes"]["3"]["population"] == 6
+    assert world["nodes"]["2"]["population"] == 7
+    assert world["nodes"]["1"]["population"] == 7


### PR DESCRIPTION
## Summary
- add `update_population_totals` to `WorldManager` to aggregate populations bottom-up
- call population aggregation when saving nodes
- test the new aggregation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f44e0b598832e88afad99dc1be023