### PR TITLE
Refresh base population during updates

### DIFF
--- a/src/world_manager.py
+++ b/src/world_manager.py
@@ -59,15 +59,20 @@ class WorldManager(WorldInterface):
             max_depth = max(max_depth, d)
 
         base_population: Dict[int, int] = {}
-        # Determine the intrinsic population for each node and persist it so
-        # repeated calls do not accumulate child populations again.
+        # Determine the intrinsic population for each node. Always recompute the
+        # base value so that changes to settlement fields are reflected on
+        # subsequent calls. Use the previously stored ``_base_population`` as the
+        # population field to avoid compounding child totals from earlier runs.
         for nid in depth_map:
             node = nodes.get(str(nid))
             if not node:
                 continue
-            if "_base_population" not in node:
-                node["_base_population"] = self.calculate_population_from_fields(node)
-            base_population[nid] = node["_base_population"]
+            base_input = dict(node)
+            if "_base_population" in node:
+                base_input["population"] = node["_base_population"]
+            base_pop = self.calculate_population_from_fields(base_input)
+            node["_base_population"] = base_pop
+            base_population[nid] = base_pop
 
         # Reset all nodes to their base population
         for nid, base_pop in base_population.items():

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -163,3 +163,27 @@ def test_population_totals_after_subfief_changes():
     assert str(new_id) not in world["nodes"]
     assert world["nodes"]["2"]["population"] == 5
     assert world["nodes"]["1"]["population"] == 5
+
+
+def test_population_totals_refresh_after_edit():
+    world = {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None, "children": [2]},
+            "2": {"node_id": 2, "parent_id": 1, "children": [], "free_peasants": 3},
+        },
+        "characters": {},
+    }
+
+    manager = WorldManager(world)
+    manager.get_depth_of_node = lambda nid: {1: 0, 2: 1}[nid]
+
+    manager.update_population_totals()
+    assert world["nodes"]["2"]["population"] == 3
+    assert world["nodes"]["1"]["population"] == 3
+
+    # Modify settlement data on node 2
+    world["nodes"]["2"]["free_peasants"] = 5
+
+    manager.update_population_totals()
+    assert world["nodes"]["2"]["population"] == 5
+    assert world["nodes"]["1"]["population"] == 5


### PR DESCRIPTION
## Summary
- recompute base population values for each node on every call to `update_population_totals`
- avoid compounding totals by using previously stored `_base_population` when calculating
- test that editing settlement fields is reflected after an update

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f6ea1c53c832e9f4f432c35f48d6f