### PR TITLE
Add soldiers resource type

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -32,6 +32,7 @@ JARLDOM_RESOURCE_TYPES = [
     "Vildmark",
     "Flod",
     "Hav",
+    "Soldater",
 ]
 
 # Categorized for easier handling in UI

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -111,6 +111,20 @@ def test_node_extra_resource_roundtrip():
     assert back["buildings"] == [{"type": "Smedja", "count": 1}]
 
 
+def test_node_soldier_large_count():
+    raw = {
+        "node_id": 30,
+        "parent_id": 1,
+        "soldiers": [{"type": "Fotsoldat", "count": "123456"}],
+    }
+
+    node = Node.from_dict(raw)
+    assert node.soldiers == [{"type": "Fotsoldat", "count": 123456}]
+
+    back = node.to_dict()
+    assert back["soldiers"] == [{"type": "Fotsoldat", "count": 123456}]
+
+
 def test_node_vildmark_tunnland_roundtrip():
     raw = {
         "node_id": 40,


### PR DESCRIPTION
## Summary
- support `Soldater` as a Jarldom resource type
- extend UI with soldier rows similar to craftsmen
- handle saving and unsaved checks for soldiers
- test large soldier counts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb9368e10832eb2e840e04a9b69da