### PR TITLE
Add Animals resource type

### DIFF
--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -125,6 +125,20 @@ def test_node_soldier_large_count():
     assert back["soldiers"] == [{"type": "Fotsoldat", "count": 123456}]
 
 
+def test_node_animal_large_count():
+    raw = {
+        "node_id": 31,
+        "parent_id": 1,
+        "animals": [{"type": "Oxe", "count": "654321"}],
+    }
+
+    node = Node.from_dict(raw)
+    assert node.animals == [{"type": "Oxe", "count": 654321}]
+
+    back = node.to_dict()
+    assert back["animals"] == [{"type": "Oxe", "count": 654321}]
+
+
 def test_node_vildmark_tunnland_roundtrip():
     raw = {
         "node_id": 40,


### PR DESCRIPTION
## Summary
- add ANIMAL_TYPES import for editor
- support editing animal resources in `_show_resource_editor`
- handle animals when saving nodes and checking for changes
- include animals in subresource updates
- test parsing of large animal counts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc6a66fe4832ea19bdb21302da3af