### PR TITLE
Add separate animal resource type

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -33,6 +33,7 @@ JARLDOM_RESOURCE_TYPES = [
     "Flod",
     "Hav",
     "Soldater",
+    "Djur",
 ]
 
 # Categorized for easier handling in UI

--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -1823,6 +1823,11 @@ class FeodalSimulator:
             else:
                 soldier_frame.grid_remove()
 
+            if res_var.get() == "Djur":
+                animal_frame.grid()
+            else:
+                animal_frame.grid_remove()
+
         res_var.trace_add("write", refresh_settlement_visibility)
         refresh_settlement_visibility()
 


### PR DESCRIPTION
## Summary
- add `Djur` to the jarldom resource types
- show animal fields only when the `Djur` type is selected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd3208074832ea218583c1ced3f72