### PR TITLE
Add character type support and ruler assignment

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -15,6 +15,7 @@ RES_TYPES = [
     # Character Types (People resources, often singular with ruler)
     "Officer", "Riddare med väpnare", "Falkenerare", "Fogde", "Härold",
     "Livmedikus", "Förvaltare", "Duvhanterare", "Malmletare", "Munskänk",
+    "Härskare",
     # Settlement Types
     "By", "Stad", "Nybygge",
     # Animal Types
@@ -34,6 +35,7 @@ JARLDOM_RESOURCE_TYPES = [
     "Hav",
     "Soldater",
     "Djur",
+    "Karaktärer",
 ]
 
 # Categorized for easier handling in UI
@@ -44,7 +46,8 @@ SOLDIER_TYPES = {
 }
 CHARACTER_TYPES = {
     "Officer", "Riddare med väpnare", "Falkenerare", "Fogde", "Härold",
-    "Livmedikus", "Förvaltare", "Duvhanterare", "Malmletare", "Munskänk"
+    "Livmedikus", "Förvaltare", "Duvhanterare", "Malmletare", "Munskänk",
+    "Härskare"
 }
 SETTLEMENT_TYPES = {"By", "Stad", "Nybygge"}
 ANIMAL_TYPES = {"Stridshästar", "Ridhästar", "Packhästar", "Draghästar", "Oxe", "Föl"}

--- a/src/world_interface.py
+++ b/src/world_interface.py
@@ -212,6 +212,12 @@ class WorldInterface(ABC):
             if "skills" not in char:
                 char["skills"] = []
                 updated = True
+            if "type" not in char:
+                char["type"] = ""
+                updated = True
+            if "ruler_of" not in char:
+                char["ruler_of"] = None
+                updated = True
             if updated:
                 chars_updated += 1
 


### PR DESCRIPTION
## Summary
- include a `Härskare` option among character types
- introduce `Karaktärer` as a jarldom resource type
- store character `type` and `ruler_of` fields and validate them
- extend character editor with type dropdown and jarldom selection
- assign jarldom rulers when saving characters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd81e69d4832e88a19ce0faa787a9