### PR TITLE
Add character row editor and roundtrip test

### DIFF
--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -154,3 +154,26 @@ def test_node_vildmark_tunnland_roundtrip():
     back = node.to_dict()
     assert back["tunnland"] == 7
     assert back["population"] == 0
+
+
+def test_node_characters_roundtrip():
+    raw = {
+        "node_id": 50,
+        "parent_id": 1,
+        "characters": [
+            {"type": "Officer"},
+            {"type": "Härskare", "ruler_id": 3},
+        ],
+    }
+
+    node = Node.from_dict(raw)
+    assert node.characters == [
+        {"type": "Officer", "ruler_id": None},
+        {"type": "Härskare", "ruler_id": 3},
+    ]
+
+    back = node.to_dict()
+    assert back["characters"] == [
+        {"type": "Officer", "ruler_id": None},
+        {"type": "Härskare", "ruler_id": 3},
+    ]


### PR DESCRIPTION
## Summary
- extend resource editor with character management
- show characters when resource type is "Karaktärer"
- include character data when saving nodes
- track character changes for unsaved warnings
- test Node round-trip with character data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880525bd63c832eae8a5e259e1842c5