### PR TITLE
Add basic HTTP server for HTML interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
 # feudal-simulator
 
 This project is a small prototype for a feudal county simulation. The code
-is split across multiple modules under `src/`. Run the application with
-`python src/simulator.py`.
+is split across multiple modules under `src/`.
+
+Run the original Tkinter GUI application with:
+
+```
+python src/simulator.py
+```
+
+A minimal HTTP server that renders the same data as HTML is also available.
+Start it with:
+
+```
+python src/http_server.py
+```
+
+Then open `http://localhost:8000` in a browser.
 
 ## Testing
 Run `pytest` in the repository root to execute the automated test suite.

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -1,0 +1,81 @@
+from wsgiref.simple_server import make_server
+import urllib.parse
+
+from data_manager import load_worlds_from_file
+
+
+def load_worlds():
+    """Load worlds from disk."""
+    try:
+        return load_worlds_from_file()
+    except Exception:
+        return {}
+
+
+def render_template(title: str, body: str) -> str:
+    """Return a basic HTML page."""
+    return f"""
+    <html>
+    <head>
+        <meta charset='utf-8'>
+        <title>{title}</title>
+        <style>
+            body {{ font-family: Arial, sans-serif; margin: 20px; }}
+            table {{ border-collapse: collapse; }}
+            th, td {{ border: 1px solid #ccc; padding: 4px 8px; }}
+            a {{ text-decoration: none; color: #0645ad; }}
+        </style>
+    </head>
+    <body>
+        {body}
+    </body>
+    </html>
+    """
+
+
+ALL_WORLDS = load_worlds()
+
+
+def application(environ, start_response):
+    path = environ.get('PATH_INFO', '/')
+    if path in ('', '/'):  # index
+        body = "<h1>Feodal Simulator</h1>\n<h2>Worlds</h2>\n<ul>"
+        for name in sorted(ALL_WORLDS.keys()):
+            link = urllib.parse.quote(name)
+            body += f"<li><a href='/world/{link}'>{name}</a></li>"
+        body += "</ul>"
+        html = render_template("Feodal Simulator", body)
+        start_response('200 OK', [('Content-Type', 'text/html; charset=utf-8')])
+        return [html.encode('utf-8')]
+
+    if path.startswith('/world/'):
+        name = urllib.parse.unquote(path[len('/world/'):])
+        data = ALL_WORLDS.get(name)
+        if not data:
+            start_response('404 Not Found', [('Content-Type', 'text/plain')])
+            return [b'World not found']
+        body = [f"<h1>{name}</h1>"]
+        body.append("<table><tr><th>ID</th><th>Name</th><th>Parent</th></tr>")
+        for nid, node in data.get('nodes', {}).items():
+            display_name = node.get('custom_name') or node.get('name')
+            parent = node.get('parent_id')
+            body.append(f"<tr><td>{nid}</td><td>{display_name}</td><td>{parent}</td></tr>")
+        body.append("</table>")
+        body.append("<p><a href='/'>Back</a></p>")
+        html = render_template(name, "\n".join(body))
+        start_response('200 OK', [('Content-Type', 'text/html; charset=utf-8')])
+        return [html.encode('utf-8')]
+
+    start_response('404 Not Found', [('Content-Type', 'text/plain')])
+    return [b'Not found']
+
+
+def main(port: int = 8000) -> None:
+    """Run a simple web server on ``port``."""
+    with make_server('', port, application) as server:
+        print(f"Serving on http://localhost:{port}")
+        server.serve_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -1,0 +1,34 @@
+import types
+from wsgiref.util import setup_testing_defaults
+
+import src.http_server as http_server
+
+
+def run_app(path):
+    environ = {}
+    setup_testing_defaults(environ)
+    environ['PATH_INFO'] = path
+    captured = {}
+
+    def start_response(status, headers):
+        captured['status'] = status
+        captured['headers'] = headers
+    body = b"".join(http_server.application(environ, start_response))
+    captured['body'] = body.decode('utf-8')
+    return captured
+
+
+def test_index_page(monkeypatch):
+    monkeypatch.setattr(http_server, 'ALL_WORLDS', {'A': {}, 'B': {}})
+    res = run_app('/')
+    assert res['status'].startswith('200')
+    assert 'Feodal Simulator' in res['body']
+    assert 'A' in res['body']
+    assert 'B' in res['body']
+
+
+def test_missing_world(monkeypatch):
+    monkeypatch.setattr(http_server, 'ALL_WORLDS', {})
+    res = run_app('/world/none')
+    assert res['status'].startswith('404')
+


### PR DESCRIPTION
## Summary
- add a small WSGI HTTP listener that exposes world data as HTML
- mention new server option in README
- test HTTP server rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880782001788322a3098fff4d250b7a