### PR TITLE
Fix missing constant import

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -18,6 +18,7 @@ from constants import (
     CRAFTSMAN_TYPES,
     SOLDIER_TYPES,
     ANIMAL_TYPES,
+    CHARACTER_TYPES,
 )
 from data_manager import load_worlds_from_file, save_worlds_to_file
 from node import Node


### PR DESCRIPTION
## Summary
- import `CHARACTER_TYPES` in `feodal_simulator.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688080295708832ebacbac564fba485d