### PR TITLE
Limit soldier/animal fields to specific resource types

### DIFF
--- a/src/node.py
+++ b/src/node.py
@@ -122,9 +122,13 @@ class Node:
                         items.append({"type": str(tval), "ruler_id": rid})
             return items
 
-        soldiers = parse_list_of_dict("soldiers", count_field=True)
+        soldiers: List[dict] = []
+        animals: List[dict] = []
+        if data.get("res_type") == "Soldater" or "soldiers" in data:
+            soldiers = parse_list_of_dict("soldiers", count_field=True)
+        if data.get("res_type") == "Djur" or "animals" in data:
+            animals = parse_list_of_dict("animals", count_field=True)
         characters = parse_list_of_dict("characters", count_field=False)
-        animals = parse_list_of_dict("animals", count_field=True)
         buildings = parse_list_of_dict("buildings", count_field=True)
 
         return cls(
@@ -153,7 +157,7 @@ class Node:
 
     def to_dict(self) -> dict:
         """Convert this Node back into a serialisable dictionary."""
-        return {
+        data = {
             "node_id": self.node_id,
             "parent_id": self.parent_id,
             "name": self.name,
@@ -176,23 +180,29 @@ class Node:
                 {"type": c.get("type", ""), "count": c.get("count", 1)}
                 for c in self.craftsmen
             ],
-            "soldiers": [
-                {"type": s.get("type", ""), "count": s.get("count", 1)}
-                for s in self.soldiers
-            ],
             "characters": [
                 {"type": c.get("type", ""), "ruler_id": c.get("ruler_id")}
                 for c in self.characters
-            ],
-            "animals": [
-                {"type": a.get("type", ""), "count": a.get("count", 1)}
-                for a in self.animals
             ],
             "buildings": [
                 {"type": b.get("type", ""), "count": b.get("count", 1)}
                 for b in self.buildings
             ],
         }
+
+        if self.res_type == "Soldater":
+            data["soldiers"] = [
+                {"type": s.get("type", ""), "count": s.get("count", 1)}
+                for s in self.soldiers
+            ]
+
+        if self.res_type == "Djur":
+            data["animals"] = [
+                {"type": a.get("type", ""), "count": a.get("count", 1)}
+                for a in self.animals
+            ]
+
+        return data
 
     def calculate_population(self) -> int:
         """Return the total population for this node based on categories."""

--- a/src/world_interface.py
+++ b/src/world_interface.py
@@ -154,7 +154,28 @@ class WorldInterface(ABC):
                 if "res_type" not in node:
                     node["res_type"] = "Resurs"
                     updated = True
-                for key in ("soldiers", "characters", "animals", "buildings"):
+                res_type = node.get("res_type")
+                # Soldiers field only for Soldier resources
+                if res_type == "Soldater":
+                    if "soldiers" not in node or not isinstance(node["soldiers"], list):
+                        node["soldiers"] = []
+                        updated = True
+                else:
+                    if "soldiers" in node:
+                        del node["soldiers"]
+                        updated = True
+
+                # Animals field only for Animal resources
+                if res_type == "Djur":
+                    if "animals" not in node or not isinstance(node["animals"], list):
+                        node["animals"] = []
+                        updated = True
+                else:
+                    if "animals" in node:
+                        del node["animals"]
+                        updated = True
+
+                for key in ("characters", "buildings"):
                     if key not in node or not isinstance(node[key], list):
                         node[key] = []
                         updated = True

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -89,32 +89,51 @@ def test_node_population_calculated_from_categories():
     assert data["population"] == 10
 
 
-def test_node_extra_resource_roundtrip():
+def test_node_soldier_roundtrip():
     raw = {
         "node_id": 20,
         "parent_id": 1,
+        "res_type": "Soldater",
         "soldiers": [{"type": "B\u00e5gskytt", "count": "2"}],
         "characters": [{"type": "Officer", "ruler_id": "5"}],
-        "animals": [{"type": "Oxe", "count": 3}],
         "buildings": [{"type": "Smedja", "count": "1"}],
     }
     node = Node.from_dict(raw)
     assert node.soldiers == [{"type": "B\u00e5gskytt", "count": 2}]
     assert node.characters == [{"type": "Officer", "ruler_id": 5}]
-    assert node.animals == [{"type": "Oxe", "count": 3}]
+    assert node.animals == []
     assert node.buildings == [{"type": "Smedja", "count": 1}]
 
     back = node.to_dict()
     assert back["soldiers"] == [{"type": "B\u00e5gskytt", "count": 2}]
     assert back["characters"] == [{"type": "Officer", "ruler_id": 5}]
-    assert back["animals"] == [{"type": "Oxe", "count": 3}]
+    assert "animals" not in back
     assert back["buildings"] == [{"type": "Smedja", "count": 1}]
+
+
+def test_node_animal_roundtrip():
+    raw = {
+        "node_id": 21,
+        "parent_id": 1,
+        "res_type": "Djur",
+        "animals": [{"type": "Oxe", "count": 3}],
+        "characters": [],
+        "buildings": [],
+    }
+    node = Node.from_dict(raw)
+    assert node.soldiers == []
+    assert node.animals == [{"type": "Oxe", "count": 3}]
+
+    back = node.to_dict()
+    assert back["animals"] == [{"type": "Oxe", "count": 3}]
+    assert "soldiers" not in back
 
 
 def test_node_soldier_large_count():
     raw = {
         "node_id": 30,
         "parent_id": 1,
+        "res_type": "Soldater",
         "soldiers": [{"type": "Fotsoldat", "count": "123456"}],
     }
 
@@ -129,6 +148,7 @@ def test_node_animal_large_count():
     raw = {
         "node_id": 31,
         "parent_id": 1,
+        "res_type": "Djur",
         "animals": [{"type": "Oxe", "count": "654321"}],
     }
 

--- a/tests/test_world_interface.py
+++ b/tests/test_world_interface.py
@@ -107,6 +107,36 @@ def test_validate_world_data_vildmark_defaults():
     assert "population" not in node
 
 
+def test_validate_world_data_resource_fields_by_type():
+    world = {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None, "res_type": "Soldater"},
+            "2": {"node_id": 2, "parent_id": None, "res_type": "Djur"},
+            "3": {
+                "node_id": 3,
+                "parent_id": None,
+                "res_type": "Resurs",
+                "soldiers": [],
+                "animals": [],
+            },
+        },
+        "characters": {},
+    }
+    manager = WorldManager(world)
+    manager.get_depth_of_node = lambda _nid: 4
+    nodes_updated, _ = manager.validate_world_data()
+    assert nodes_updated > 0
+    node1 = world["nodes"]["1"]
+    node2 = world["nodes"]["2"]
+    node3 = world["nodes"]["3"]
+    assert "soldiers" in node1 and node1["soldiers"] == []
+    assert "animals" not in node1
+    assert "animals" in node2 and node2["animals"] == []
+    assert "soldiers" not in node2
+    assert "soldiers" not in node3
+    assert "animals" not in node3
+
+
 def test_update_neighbors_for_node_bidirectional():
     world = {
         "nodes": {


### PR DESCRIPTION
## Summary
- restrict parsing and serialization of `soldiers` and `animals` in `Node`
- conditionally manage `soldiers`/`animals` in `WorldInterface.validate_world_data`
- update unit tests for new behaviour
- add tests covering new validation rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688089b8c4ec832ebb3be722d61b2955