### PR TITLE
Add dagsverken support

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -94,3 +94,12 @@ LEVNADSKOSTNADER = [
     "Mycket gott leverne",
     "Lyxliv",
 ]
+
+# Work duty levels used for jarldoms
+DAGSVERKEN_LEVELS = [
+    "inga",
+    "få",
+    "normalt",
+    "många",
+    "galet många",
+]

--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -19,6 +19,7 @@ from constants import (
     SOLDIER_TYPES,
     ANIMAL_TYPES,
     CHARACTER_TYPES,
+    DAGSVERKEN_LEVELS,
 )
 from data_manager import load_worlds_from_file, save_worlds_to_file
 from node import Node
@@ -1602,6 +1603,14 @@ class FeodalSimulator:
 
         row_idx += 1
 
+        # Work duty level
+        ttk.Label(editor_frame, text="Dagsverken:").grid(row=row_idx, column=0, sticky="w", padx=5, pady=3)
+        dags_var = tk.StringVar(value=node_data.get("dagsverken", "normalt"))
+        dags_combo = ttk.Combobox(editor_frame, textvariable=dags_var, values=DAGSVERKEN_LEVELS, state="readonly")
+        dags_combo.grid(row=row_idx, column=1, sticky="w", padx=5, pady=3)
+
+        row_idx += 1
+
         # Number of Subfiefs (Resources under the Jarldom)
         ttk.Label(editor_frame, text="Antal Underresurser:").grid(row=row_idx, column=0, sticky="w", padx=5, pady=3)
         sub_var = tk.StringVar(value=str(node_data.get("num_subfiefs", 0)))
@@ -1636,6 +1645,7 @@ class FeodalSimulator:
                 node_data["num_subfiefs"] = target_subfiefs
             except (tk.TclError, ValueError):
                 node_data["num_subfiefs"] = 0
+            node_data["dagsverken"] = dags_var.get()
             node_data["res_type"] = "Resurs" # Ensure internal type is correct
 
             self.update_subfiefs_for_node(node_data)
@@ -1647,6 +1657,7 @@ class FeodalSimulator:
         def save_node_action():
             old_custom_name = node_data.get("custom_name", "")
             old_pop = node_data.get("population", 0)
+            old_dags = node_data.get("dagsverken", "normalt")
 
             new_custom_name = custom_name_var.get().strip()
             if not new_custom_name:
@@ -1656,6 +1667,7 @@ class FeodalSimulator:
                 new_pop = int(pop_var.get() or "0")
             except (tk.TclError, ValueError):
                 new_pop = 0
+            new_dags = dags_var.get()
             # num_subfiefs saved via its own button
 
             changes_made = False
@@ -1666,6 +1678,8 @@ class FeodalSimulator:
             if old_pop != new_pop:
                 node_data["population"] = new_pop; changes_made = True
                 status_details.append(f"Befolkning: {old_pop} -> {new_pop}")
+            if old_dags != new_dags:
+                node_data["dagsverken"] = new_dags; changes_made = True
 
             # Handle ruler assignment
             selected_val = option_map.get(ruler_var.get())
@@ -1747,6 +1761,7 @@ class FeodalSimulator:
                 custom_name_var.get().strip() != node_data.get("custom_name", "")
                 or current_pop != node_data.get("population", 0)
                 or current_sub != node_data.get("num_subfiefs", 0)
+                or dags_var.get() != node_data.get("dagsverken", "normalt")
             )
 
         delete_button = self._create_delete_button(delete_back_frame, node_data, unsaved_changes)

--- a/src/node.py
+++ b/src/node.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import List, Optional
 
-from constants import MAX_NEIGHBORS, NEIGHBOR_NONE_STR
+from constants import MAX_NEIGHBORS, NEIGHBOR_NONE_STR, DAGSVERKEN_LEVELS
 
 
 @dataclass
@@ -26,6 +26,7 @@ class Node:
     neighbors: List[Neighbor] = field(default_factory=list)
     res_type: str = "Resurs"
     settlement_type: str = "By"
+    dagsverken: str = "normalt"
     free_peasants: int = 0
     unfree_peasants: int = 0
     thralls: int = 0
@@ -70,6 +71,9 @@ class Node:
                 neighbors.append(Neighbor())
 
         settlement_type = data.get("settlement_type", "By")
+        dagsverken = data.get("dagsverken", "normalt")
+        if dagsverken not in DAGSVERKEN_LEVELS:
+            dagsverken = "normalt"
         free_peasants = int(data.get("free_peasants", 0) or 0)
         unfree_peasants = int(data.get("unfree_peasants", 0) or 0)
         thralls = int(data.get("thralls", 0) or 0)
@@ -143,6 +147,7 @@ class Node:
             neighbors=neighbors,
             res_type=res_type,
             settlement_type=settlement_type,
+            dagsverken=dagsverken,
             free_peasants=free_peasants,
             unfree_peasants=unfree_peasants,
             thralls=thralls,
@@ -171,6 +176,7 @@ class Node:
             ],
             "res_type": self.res_type,
             "settlement_type": self.settlement_type,
+            "dagsverken": self.dagsverken,
             "free_peasants": self.free_peasants,
             "unfree_peasants": self.unfree_peasants,
             "thralls": self.thralls,

--- a/src/world_interface.py
+++ b/src/world_interface.py
@@ -9,6 +9,7 @@ from constants import (
     MAX_NEIGHBORS,
     NEIGHBOR_NONE_STR,
     NEIGHBOR_OTHER_STR,
+    DAGSVERKEN_LEVELS,
 )
 
 
@@ -150,6 +151,9 @@ class WorldInterface(ABC):
                     if node.get("neighbors") != validated_neighbors:
                         node["neighbors"] = validated_neighbors
                         updated = True
+                if "dagsverken" not in node or node["dagsverken"] not in DAGSVERKEN_LEVELS:
+                    node["dagsverken"] = "normalt"
+                    updated = True
             elif depth >= 4:
                 if "res_type" not in node:
                     node["res_type"] = "Resurs"

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -34,6 +34,7 @@ def test_node_from_dict_normalizes_fields():
     assert node.thralls == 0
     assert node.burghers == 0
     assert node.craftsmen == []
+    assert node.dagsverken == "normalt"
 
 
 def test_node_settlement_roundtrip():
@@ -72,6 +73,20 @@ def test_node_settlement_roundtrip():
         {"type": "Smed", "count": 3},
         {"type": "Bagare", "count": 1},
     ]
+
+
+def test_node_dagsverken_roundtrip():
+    raw = {
+        "node_id": 60,
+        "parent_id": 1,
+        "dagsverken": "många",
+    }
+
+    node = Node.from_dict(raw)
+    assert node.dagsverken == "många"
+
+    back = node.to_dict()
+    assert back["dagsverken"] == "många"
 
 
 def test_node_population_calculated_from_categories():


### PR DESCRIPTION
## Summary
- add `DAGSVERKEN_LEVELS` constant
- add `dagsverken` attribute to `Node`
- include dagsverken selection in jarldom editor
- validate dagsverken in `WorldInterface`
- add unit tests for dagsverken

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c9d9f798832eb585d53d7767321b