### PR TITLE
Add hierarchical grouping layout for static map

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -2852,6 +2852,7 @@ class FeodalSimulator:
         btn_fr = ttk.Frame(self.right_frame, style="Tool.TFrame")
         btn_fr.pack(fill="x", pady=5)
         ttk.Button(btn_fr, text="< Tillbaka", command=self.show_no_world_view).pack(side=tk.LEFT, padx=5)
+        ttk.Button(btn_fr, text="Gruppera Hierarki", command=self.on_hierarchy_layout).pack(side=tk.LEFT, padx=5)
 
         self.static_scale = 1.0
         self.static_map_canvas.bind("<MouseWheel>", self.on_static_map_zoom) # Windows/macOS
@@ -2894,6 +2895,28 @@ class FeodalSimulator:
         self.static_grid_occupied = self.map_logic.static_grid_occupied
         self.static_rows = self.map_logic.rows
         self.static_cols = self.map_logic.cols
+
+    def place_jarldomes_hierarchy(self):
+        """Places Jarldoms grouped by hierarchy using :class:`StaticMapLogic`."""
+        if not self.map_logic:
+            self.map_logic = StaticMapLogic(
+                self.world_data,
+                self.static_rows,
+                self.static_cols,
+                hex_size=30,
+                spacing=self.hex_spacing,
+            )
+        self.map_logic.place_jarldomes_hierarchy(self.get_depth_of_node)
+        self.map_static_positions = self.map_logic.map_static_positions
+        self.static_grid_occupied = self.map_logic.static_grid_occupied
+        self.static_rows = self.map_logic.rows
+        self.static_cols = self.map_logic.cols
+
+    def on_hierarchy_layout(self):
+        """Callback for hierarchy grouping button."""
+        self.place_jarldomes_hierarchy()
+        self.draw_static_hexgrid()
+        self.draw_static_border_lines()
 
     def draw_static_hexgrid(self):
         """Draws the hex grid and places Jarldom names."""

--- a/tests/test_map_logic.py
+++ b/tests/test_map_logic.py
@@ -140,3 +140,40 @@ def test_border_lines_unidirectional_neighbor():
     lines = logic.border_lines()
     assert len(lines) == 1
 
+
+def test_hierarchy_layout_simple():
+    nodes = {
+        "1": {"node_id": 1, "parent_id": None},
+        "2": {"node_id": 2, "parent_id": 1},
+        "3": {"node_id": 3, "parent_id": 1},
+        "10": {"node_id": 10, "parent_id": 2},
+        "11": {"node_id": 11, "parent_id": 2},
+        "20": {"node_id": 20, "parent_id": 3},
+        "101": {"node_id": 101, "parent_id": 10, "neighbors": []},
+        "102": {"node_id": 102, "parent_id": 10, "neighbors": []},
+        "111": {"node_id": 111, "parent_id": 11, "neighbors": []},
+        "201": {"node_id": 201, "parent_id": 20, "neighbors": []},
+    }
+    world = {"nodes": nodes, "characters": {}}
+
+    def depth(nid: int) -> int:
+        d = 0
+        while True:
+            node = nodes.get(str(nid))
+            if not node:
+                break
+            pid = node.get("parent_id")
+            if pid is None:
+                break
+            nid = pid
+            d += 1
+        return d
+
+    logic = StaticMapLogic(world, rows=10, cols=10, hex_size=30, spacing=15)
+    logic.place_jarldomes_hierarchy(depth)
+
+    assert logic.map_static_positions[101] == (0, 0)
+    assert logic.map_static_positions[102] == (1, 0)
+    assert logic.map_static_positions[111] == (0, 3)
+    assert logic.map_static_positions[201] == (7, 0)
+


### PR DESCRIPTION
## Summary
- add `place_jarldomes_hierarchy` to `StaticMapLogic`
- support hierarchy layout through new `place_jarldomes_hierarchy` and button in simulator
- test hierarchical placement logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881cce3ae3c8322bc9c41b8ccf044a3