### PR TITLE
Improve hierarchy cluster layout

### DIFF
--- a/src/map_logic.py
+++ b/src/map_logic.py
@@ -144,16 +144,19 @@ class StaticMapLogic:
         self.map_static_positions = {}
         self.static_grid_occupied = [[None] * self.cols for _ in range(self.rows)]
 
-        row = 0
+        border_pad = 1  # keep groups away from the map edges
+        row = border_pad
         FUR_GAP = 5
         HER_GAP = 2
         for _fur_id, h_dict in groups.items():
-            col = 0
+            col = border_pad
             fur_height = 0
             for _her_id, j_list in h_dict.items():
+                cluster_rows = int(math.ceil(math.sqrt(len(j_list)))) or 1
+                cluster_cols = int(math.ceil(len(j_list) / cluster_rows)) or 1
                 for j_idx, jid in enumerate(sorted(j_list)):
-                    r = row + j_idx
-                    c = col
+                    r = row + (j_idx // cluster_cols)
+                    c = col + (j_idx % cluster_cols)
                     while r >= self.rows:
                         self.static_grid_occupied.append([None] * self.cols)
                         self.rows += 1
@@ -163,8 +166,8 @@ class StaticMapLogic:
                         self.cols += 1
                     self.map_static_positions[jid] = (r, c)
                     self.static_grid_occupied[r][c] = jid
-                fur_height = max(fur_height, len(j_list))
-                col += 1 + HER_GAP
+                fur_height = max(fur_height, cluster_rows)
+                col += cluster_cols + HER_GAP
             row += fur_height + FUR_GAP
 
     # --------------------------------------------------

--- a/tests/test_map_logic.py
+++ b/tests/test_map_logic.py
@@ -172,8 +172,8 @@ def test_hierarchy_layout_simple():
     logic = StaticMapLogic(world, rows=10, cols=10, hex_size=30, spacing=15)
     logic.place_jarldomes_hierarchy(depth)
 
-    assert logic.map_static_positions[101] == (0, 0)
-    assert logic.map_static_positions[102] == (1, 0)
-    assert logic.map_static_positions[111] == (0, 3)
-    assert logic.map_static_positions[201] == (7, 0)
+    assert logic.map_static_positions[101] == (1, 1)
+    assert logic.map_static_positions[102] == (2, 1)
+    assert logic.map_static_positions[111] == (1, 4)
+    assert logic.map_static_positions[201] == (8, 1)
 


### PR DESCRIPTION
## Summary
- arrange hierarchy layout in clusters instead of lines
- keep a one cell margin from the north and west borders
- update tests for new placement logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881cf6b62848322b964e07b93c73398