### PR TITLE
Enable border editing on static map

### DIFF
--- a/src/map_logic.py
+++ b/src/map_logic.py
@@ -240,9 +240,11 @@ class StaticMapLogic:
         angle = math.degrees(math.atan2(cy1 - cy2, cx2 - cx1))
         return int(round(((90 - angle) % 360) / 60)) + 1
 
-    def border_lines(self) -> List[Tuple[float, float, float, float, str, int]]:
-        """Return list of lines between neighbors."""
-        lines: List[Tuple[float, float, float, float, str, int]] = []
+    def border_lines_with_ids(
+        self,
+    ) -> List[Tuple[float, float, float, float, str, int, int, int]]:
+        """Return line coordinates with colors and the connected node ids."""
+        lines: List[Tuple[float, float, float, float, str, int, int, int]] = []
         drawn_pairs: set[tuple[int, int]] = set()
         nodes_dict = self.world_data.get("nodes", {})
         for r in range(self.rows):
@@ -265,7 +267,6 @@ class StaticMapLogic:
                             continue
                         drawn_pairs.add(pair)
 
-                        # Determine which node should be treated as the start
                         if jid <= nbid:
                             start_r, start_c = r, c
                             start_idx = idx + 1
@@ -293,8 +294,17 @@ class StaticMapLogic:
                             nb.get("border", NEIGHBOR_NONE_STR), "gray"
                         )
                         width = 3 if color in ["black", "brown", "blue"] else 2
-                        lines.append((start_x, start_y, end_x, end_y, color, width))
+                        lines.append(
+                            (start_x, start_y, end_x, end_y, color, width, jid, nbid)
+                        )
         return lines
+
+    def border_lines(self) -> List[Tuple[float, float, float, float, str, int]]:
+        """Return list of lines between neighbors for drawing."""
+        return [
+            (x1, y1, x2, y2, color, width)
+            for x1, y1, x2, y2, color, width, _jid1, _jid2 in self.border_lines_with_ids()
+        ]
 
     def adjacent_hex_pairs(self) -> List[Tuple[int, int, int]]:
         """Return pairs of adjacent nodes on the grid.

--- a/src/world_manager.py
+++ b/src/world_manager.py
@@ -5,7 +5,7 @@ import math
 from typing import Any, Dict, List
 
 from utils import generate_swedish_village_name
-from constants import MAX_NEIGHBORS, NEIGHBOR_NONE_STR
+from constants import MAX_NEIGHBORS, NEIGHBOR_NONE_STR, BORDER_TYPES
 from node import Node
 from world_interface import WorldInterface
 
@@ -587,3 +587,27 @@ class WorldManager(WorldInterface):
             other_neighbors[opp_idx]["border"] = border_val
 
         node["neighbors"] = new_neighbors
+
+    def set_border_between(self, node_id1: int, node_id2: int, border_type: str) -> bool:
+        """Set border type for the connection between two nodes."""
+        if border_type not in BORDER_TYPES:
+            border_type = NEIGHBOR_NONE_STR
+        nodes = self.world_data.get("nodes", {})
+        n1 = nodes.get(str(node_id1))
+        n2 = nodes.get(str(node_id2))
+        if not n1 or not n2:
+            return False
+
+        changed = False
+        for nb in n1.get("neighbors", []):
+            if nb.get("id") == node_id2:
+                if nb.get("border") != border_type:
+                    nb["border"] = border_type
+                    changed = True
+        for nb in n2.get("neighbors", []):
+            if nb.get("id") == node_id1:
+                if nb.get("border") != border_type:
+                    nb["border"] = border_type
+                    changed = True
+
+        return changed


### PR DESCRIPTION
## Summary
- allow border lines to carry node IDs
- handle right-clicks on border lines on the static map
- store updated border types via WorldManager

## Testing
- `pytest -q`
- `pytest tests/test_map_logic.py::test_placement_and_border_lines -q`


------
https://chatgpt.com/codex/tasks/task_e_6881d9060e1083229dd06f0074c53198