### PR TITLE
Improve border click area

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -3030,6 +3030,24 @@ class FeodalSimulator:
                 width=width,
                 tags=("border_line", tag),
             )
+
+            # Add an invisible polygon covering the gap so right-clicking is easier
+            pos1 = self.map_static_positions.get(id1)
+            pos2 = self.map_static_positions.get(id2)
+            if pos1 and pos2:
+                r1, c1 = pos1
+                r2, c2 = pos2
+                direction = self.map_logic.direction_index(r1, c1, r2, c2)
+                p1, p2 = self.map_logic.hex_side_points(r1, c1, direction)
+                opp = ((direction + 2) % MAX_NEIGHBORS) + 1
+                p3, p4 = self.map_logic.hex_side_points(r2, c2, opp)
+                self.static_map_canvas.create_polygon(
+                    *p1, *p2, *p3, *p4,
+                    fill="",
+                    outline="",
+                    tags=("border_line", tag),
+                )
+
             self.static_map_canvas.tag_bind(tag, "<ButtonPress-3>", self.on_border_right_click)
 
     def on_border_right_click(self, event):

--- a/src/map_logic.py
+++ b/src/map_logic.py
@@ -233,6 +233,31 @@ class StaticMapLogic:
         y = cy + self.hex_size * math.sin(angle_rad)
         return x, y
 
+    def hex_side_points(
+        self, r: int, c: int, direction: int
+    ) -> Tuple[Tuple[float, float], Tuple[float, float]]:
+        """Return the endpoint coordinates for a hexagon side.
+
+        ``direction`` should be ``1-6`` with ``1`` at the north side and
+        increasing clockwise. The points are ordered counter-clockwise around the
+        hexagon.
+        """
+        cx, cy = self.hex_center(r, c)
+        angles = {
+            1: (60, 120),
+            2: (0, 60),
+            3: (300, 0),
+            4: (240, 300),
+            5: (180, 240),
+            6: (120, 180),
+        }
+        a1, a2 = angles.get(direction, (0, 0))
+        x1 = cx + self.hex_size * math.cos(math.radians(a1))
+        y1 = cy + self.hex_size * math.sin(math.radians(a1))
+        x2 = cx + self.hex_size * math.cos(math.radians(a2))
+        y2 = cy + self.hex_size * math.sin(math.radians(a2))
+        return (x1, y1), (x2, y2)
+
     def direction_index(self, r1: int, c1: int, r2: int, c2: int) -> int:
         """Return direction index (1-6) from (r1, c1) to (r2, c2)."""
         cx1, cy1 = self.hex_center(r1, c1)


### PR DESCRIPTION
## Summary
- add `hex_side_points` helper for hexagon vertices
- build transparent polygons over static map borders
  so right-clicking borders is easier

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881db6688bc832286563d13781a9d87