### PR TITLE
Add buildings resource type

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -36,6 +36,7 @@ JARLDOM_RESOURCE_TYPES = [
     "Soldater",
     "Djur",
     "Karaktärer",
+    "Byggnader",
 ]
 
 # Categorized for easier handling in UI

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -49,6 +49,28 @@ def test_aggregate_resources_simple():
     assert totals["animals"]["Oxe"] == 1
 
 
+def test_aggregate_resources_buildings():
+    world = {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None, "children": [2]},
+            "2": {
+                "node_id": 2,
+                "parent_id": 1,
+                "children": [],
+                "buildings": [
+                    {"type": "Smedja", "count": 1},
+                    {"type": "Bageri", "count": 2},
+                ],
+            },
+        },
+        "characters": {},
+    }
+    manager = WorldManager(world)
+    totals = manager.aggregate_resources(1)
+    assert totals["buildings"]["Smedja"] == 1
+    assert totals["buildings"]["Bageri"] == 2
+
+
 def test_calculate_total_resources_recursive():
     world = {
         "nodes": {


### PR DESCRIPTION
## Summary
- introduce a new `Byggnader` resource category
- add buildings editor with dropdown rows like craftsmen
- aggregate building counts in the hierarchy
- test building aggregation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68824aa8c4bc832e894fe1fe80ff81f3