### PR TITLE
Fix resource type normalization

### DIFF
--- a/src/node.py
+++ b/src/node.py
@@ -81,7 +81,8 @@ class Node:
         tunnland = int(data.get("tunnland", 0) or 0)
         base_pop = int(data.get("population", 0) or 0)
         computed_pop = free_peasants + unfree_peasants + thralls + burghers
-        res_type = data.get("res_type", "Resurs")
+        res_type_raw = data.get("res_type", "Resurs")
+        res_type = res_type_raw if isinstance(res_type_raw, str) and res_type_raw else "Resurs"
         if res_type == "Vildmark":
             population = 0
         elif computed_pop:
@@ -174,7 +175,7 @@ class Node:
             "neighbors": [
                 {"id": nb.id, "border": nb.border} for nb in self.neighbors
             ],
-            "res_type": self.res_type,
+            "res_type": str(self.res_type) if self.res_type is not None else "Resurs",
             "settlement_type": self.settlement_type,
             "dagsverken": self.dagsverken,
             "free_peasants": self.free_peasants,

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -212,3 +212,14 @@ def test_node_characters_roundtrip():
         {"type": "Officer", "ruler_id": None},
         {"type": "Härskare", "ruler_id": 3},
     ]
+
+
+def test_node_res_type_invalid_defaults_to_resurs():
+    raw = {"node_id": 60, "parent_id": None, "res_type": 123}
+
+    node = Node.from_dict(raw)
+
+    assert node.res_type == "Resurs"
+
+    back = node.to_dict()
+    assert back["res_type"] == "Resurs"


### PR DESCRIPTION
## Summary
- normalize `res_type` in `Node.from_dict`
- ensure `Node.to_dict` always emits a string value for `res_type`
- test invalid `res_type` handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688278c27a60832eb1a1876448125970