### PR TITLE
Restrict animal feature to Djur resources

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -2407,11 +2407,14 @@ class FeodalSimulator:
                 for r in character_rows
                 if r["type_var"].get()
             ]
-            node_data["animals"] = [
-                {"type": r["type_var"].get(), "count": int(r["count_var"].get() or 0)}
-                for r in animal_rows
-                if r["type_var"].get()
-            ]
+            if res_var.get() == "Djur":
+                node_data["animals"] = [
+                    {"type": r["type_var"].get(), "count": int(r["count_var"].get() or 0)}
+                    for r in animal_rows
+                    if r["type_var"].get()
+                ]
+            else:
+                node_data.pop("animals", None)
             node_data["buildings"] = [
                 {"type": r["type_var"].get(), "count": int(r["count_var"].get() or 0)}
                 for r in building_rows
@@ -2507,11 +2510,14 @@ class FeodalSimulator:
                 for r in character_rows
                 if r["type_var"].get()
             ]
-            new_animals = [
-                {"type": r["type_var"].get(), "count": int(r["count_var"].get() or 0)}
-                for r in animal_rows
-                if r["type_var"].get()
-            ]
+            if new_type == "Djur":
+                new_animals = [
+                    {"type": r["type_var"].get(), "count": int(r["count_var"].get() or 0)}
+                    for r in animal_rows
+                    if r["type_var"].get()
+                ]
+            else:
+                new_animals = []
             new_buildings = [
                 {"type": r["type_var"].get(), "count": int(r["count_var"].get() or 0)}
                 for r in building_rows
@@ -2532,11 +2538,6 @@ class FeodalSimulator:
                     ),
                 }
                 for r in character_rows
-                if r["type_var"].get()
-            ]
-            new_animals = [
-                {"type": r["type_var"].get(), "count": int(r["count_var"].get() or 0)}
-                for r in animal_rows
                 if r["type_var"].get()
             ]
 
@@ -2595,9 +2596,14 @@ class FeodalSimulator:
             if old_soldiers != new_soldiers:
                 node_data["soldiers"] = new_soldiers
                 changes = True
-            if old_animals != new_animals:
-                node_data["animals"] = new_animals
-                changes = True
+            if new_type == "Djur":
+                if old_animals != new_animals:
+                    node_data["animals"] = new_animals
+                    changes = True
+            else:
+                if "animals" in node_data:
+                    del node_data["animals"]
+                    changes = True
             if old_buildings != new_buildings:
                 node_data["buildings"] = new_buildings
                 changes = True
@@ -2669,11 +2675,14 @@ class FeodalSimulator:
                 for r in character_rows
                 if r["type_var"].get()
             ]
-            new_animals = [
-                {"type": r["type_var"].get(), "count": int(r["count_var"].get() or 0)}
-                for r in animal_rows
-                if r["type_var"].get()
-            ]
+            if res_var.get() == "Djur":
+                new_animals = [
+                    {"type": r["type_var"].get(), "count": int(r["count_var"].get() or 0)}
+                    for r in animal_rows
+                    if r["type_var"].get()
+                ]
+            else:
+                new_animals = []
             new_buildings = [
                 {"type": r["type_var"].get(), "count": int(r["count_var"].get() or 0)}
                 for r in building_rows

--- a/src/node.py
+++ b/src/node.py
@@ -131,7 +131,7 @@ class Node:
         animals: List[dict] = []
         if data.get("res_type") == "Soldater" or "soldiers" in data:
             soldiers = parse_list_of_dict("soldiers", count_field=True)
-        if data.get("res_type") == "Djur" or "animals" in data:
+        if data.get("res_type") == "Djur":
             animals = parse_list_of_dict("animals", count_field=True)
         characters = parse_list_of_dict("characters", count_field=False)
         buildings = parse_list_of_dict("buildings", count_field=True)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -174,6 +174,21 @@ def test_node_animal_large_count():
     assert back["animals"] == [{"type": "Oxe", "count": 654321}]
 
 
+def test_node_ignores_animals_for_non_djur():
+    raw = {
+        "node_id": 32,
+        "parent_id": 1,
+        "res_type": "Resurs",
+        "animals": [{"type": "Oxe", "count": 2}],
+    }
+
+    node = Node.from_dict(raw)
+    assert node.animals == []
+
+    back = node.to_dict()
+    assert "animals" not in back
+
+
 def test_node_vildmark_tunnland_roundtrip():
     raw = {
         "node_id": 40,


### PR DESCRIPTION
## Summary
- load animal data only when `res_type` is `Djur`
- manage animal lists based on selected resource type in the GUI
- ensure nodes ignore animals when not of type `Djur`
- test that non‑animal resources drop animal data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883148fb520832eb324a3ba041e7ab8