### PR TITLE
Add 'Mark' resource type with land fields

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -31,6 +31,7 @@ JARLDOM_RESOURCE_TYPES = [
     "Gods",
     "Bosättning",
     "Vildmark",
+    "Mark",
     "Flod",
     "Hav",
     "Soldater",

--- a/src/node.py
+++ b/src/node.py
@@ -38,6 +38,9 @@ class Node:
     thralls: int = 0
     burghers: int = 0
     tunnland: int = 0  # Area for wilderness resources measured in tunnland
+    total_land: int = 0  # Total land area for 'Mark' resources
+    forest_land: int = 0
+    cleared_land: int = 0
     craftsmen: List[dict] = field(default_factory=list)
     soldiers: List[dict] = field(default_factory=list)
     characters: List[dict] = field(default_factory=list)
@@ -87,6 +90,9 @@ class Node:
         thralls = int(data.get("thralls", 0) or 0)
         burghers = int(data.get("burghers", 0) or 0)
         tunnland = int(data.get("tunnland", 0) or 0)
+        total_land = int(data.get("total_land", 0) or 0)
+        forest_land = int(data.get("forest_land", 0) or 0)
+        cleared_land = int(data.get("cleared_land", 0) or 0)
         base_pop = int(data.get("population", 0) or 0)
         computed_pop = free_peasants + unfree_peasants + thralls + burghers
         res_type_raw = data.get("res_type", "Resurs")
@@ -175,6 +181,9 @@ class Node:
             thralls=thralls,
             burghers=burghers,
             tunnland=tunnland,
+            total_land=total_land,
+            forest_land=forest_land,
+            cleared_land=cleared_land,
             craftsmen=craftsmen,
             soldiers=soldiers,
             characters=characters,
@@ -206,6 +215,9 @@ class Node:
             "thralls": self.thralls,
             "burghers": self.burghers,
             "tunnland": self.tunnland,
+            "total_land": self.total_land,
+            "forest_land": self.forest_land,
+            "cleared_land": self.cleared_land,
             "craftsmen": [
                 {"type": c.get("type", ""), "count": c.get("count", 1)}
                 for c in self.craftsmen

--- a/src/world_interface.py
+++ b/src/world_interface.py
@@ -108,10 +108,16 @@ class WorldInterface(ABC):
             if "children" not in node:
                 node["children"] = []
                 updated = True
-            if node.get("res_type") == "Vildmark":
+            res_type = node.get("res_type")
+            if res_type == "Vildmark":
                 if "tunnland" not in node:
                     node["tunnland"] = 0
                     updated = True
+            elif res_type == "Mark":
+                for key in ("total_land", "forest_land", "cleared_land"):
+                    if key not in node:
+                        node[key] = 0
+                        updated = True
             else:
                 if "population" not in node:
                     node["population"] = 0
@@ -178,6 +184,18 @@ class WorldInterface(ABC):
                     if "animals" in node:
                         del node["animals"]
                         updated = True
+
+                # Land fields only for Mark resources
+                if res_type == "Mark":
+                    for key in ("total_land", "forest_land", "cleared_land"):
+                        if key not in node:
+                            node[key] = 0
+                            updated = True
+                else:
+                    for key in ("total_land", "forest_land", "cleared_land"):
+                        if key in node:
+                            del node[key]
+                            updated = True
 
                 for key in ("characters", "buildings"):
                     if key not in node or not isinstance(node[key], list):

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -206,6 +206,28 @@ def test_node_vildmark_tunnland_roundtrip():
     assert back["population"] == 0
 
 
+def test_node_mark_land_roundtrip():
+    raw = {
+        "node_id": 41,
+        "parent_id": 1,
+        "res_type": "Mark",
+        "total_land": 20,
+        "forest_land": 15,
+        "cleared_land": 5,
+    }
+
+    node = Node.from_dict(raw)
+
+    assert node.total_land == 20
+    assert node.forest_land == 15
+    assert node.cleared_land == 5
+
+    back = node.to_dict()
+    assert back["total_land"] == 20
+    assert back["forest_land"] == 15
+    assert back["cleared_land"] == 5
+
+
 def test_node_water_fields_roundtrip():
     raw = {
         "node_id": 70,

--- a/tests/test_world_interface.py
+++ b/tests/test_world_interface.py
@@ -119,6 +119,7 @@ def test_validate_world_data_resource_fields_by_type():
                 "soldiers": [],
                 "animals": [],
             },
+            "4": {"node_id": 4, "parent_id": None, "res_type": "Mark"},
         },
         "characters": {},
     }
@@ -129,12 +130,16 @@ def test_validate_world_data_resource_fields_by_type():
     node1 = world["nodes"]["1"]
     node2 = world["nodes"]["2"]
     node3 = world["nodes"]["3"]
+    node4 = world["nodes"]["4"]
     assert "soldiers" in node1 and node1["soldiers"] == []
     assert "animals" not in node1
     assert "animals" in node2 and node2["animals"] == []
     assert "soldiers" not in node2
     assert "soldiers" not in node3
     assert "animals" not in node3
+    assert "total_land" in node4 and "forest_land" in node4 and "cleared_land" in node4
+    assert "soldiers" not in node4
+    assert "animals" not in node4
 
 
 def test_update_neighbors_for_node_bidirectional():


### PR DESCRIPTION
## Summary
- support a new Jarldom resource type `Mark`
- track land areas with `total_land`, `forest_land`, and `cleared_land`
- ensure world validation populates these fields
- update node logic and tests for new fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688366b2a760832e9d698fbbb5ab0a6b