### PR TITLE
Add Jaktmark resource node

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -15,6 +15,7 @@ RES_TYPES = [
     # Character Types (People resources, often singular with ruler)
     "Officer", "Riddare med väpnare", "Falkenerare", "Fogde", "Härold",
     "Livmedikus", "Förvaltare", "Duvhanterare", "Malmletare", "Munskänk",
+    "Jägarmästare",
     "Härskare",
     # Settlement Types
     "By", "Stad", "Nybygge",
@@ -31,6 +32,7 @@ JARLDOM_RESOURCE_TYPES = [
     "Gods",
     "Bosättning",
     "Vildmark",
+    "Jaktmark",
     "Mark",
     "Flod",
     "Hav",
@@ -49,6 +51,7 @@ SOLDIER_TYPES = {
 CHARACTER_TYPES = {
     "Officer", "Riddare med väpnare", "Falkenerare", "Fogde", "Härold",
     "Livmedikus", "Förvaltare", "Duvhanterare", "Malmletare", "Munskänk",
+    "Jägarmästare",
     "Härskare"
 }
 SETTLEMENT_TYPES = {"By", "Stad", "Nybygge"}

--- a/src/world_interface.py
+++ b/src/world_interface.py
@@ -113,6 +113,16 @@ class WorldInterface(ABC):
                 if "tunnland" not in node:
                     node["tunnland"] = 0
                     updated = True
+            elif res_type == "Jaktmark":
+                if "tunnland" not in node:
+                    node["tunnland"] = 0
+                    updated = True
+                if "hunters" not in node:
+                    node["hunters"] = 0
+                    updated = True
+                if "gamekeeper_id" not in node:
+                    node["gamekeeper_id"] = None
+                    updated = True
             elif res_type == "Mark":
                 for key in ("total_land", "forest_land", "cleared_land"):
                     if key not in node:
@@ -191,6 +201,16 @@ class WorldInterface(ABC):
                         if key not in node:
                             node[key] = 0
                             updated = True
+                elif res_type == "Jaktmark":
+                    if "tunnland" not in node:
+                        node["tunnland"] = 0
+                        updated = True
+                    if "hunters" not in node:
+                        node["hunters"] = 0
+                        updated = True
+                    if "gamekeeper_id" not in node:
+                        node["gamekeeper_id"] = None
+                        updated = True
                 else:
                     for key in ("total_land", "forest_land", "cleared_land"):
                         if key in node:

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -206,6 +206,28 @@ def test_node_vildmark_tunnland_roundtrip():
     assert back["population"] == 0
 
 
+def test_node_jaktmark_roundtrip():
+    raw = {
+        "node_id": 45,
+        "parent_id": 1,
+        "res_type": "Jaktmark",
+        "tunnland": 12,
+        "hunters": 3,
+        "gamekeeper_id": "5",
+    }
+
+    node = Node.from_dict(raw)
+    assert node.tunnland == 12
+    assert node.hunters == 3
+    assert node.gamekeeper_id == 5
+    assert node.population == 0
+
+    back = node.to_dict()
+    assert back["tunnland"] == 12
+    assert back["hunters"] == 3
+    assert back["gamekeeper_id"] == 5
+
+
 def test_node_mark_land_roundtrip():
     raw = {
         "node_id": 41,

--- a/tests/test_world_interface.py
+++ b/tests/test_world_interface.py
@@ -142,6 +142,23 @@ def test_validate_world_data_resource_fields_by_type():
     assert "animals" not in node4
 
 
+def test_validate_world_data_jaktmark_defaults():
+    world = {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None, "res_type": "Jaktmark"}
+        },
+        "characters": {},
+    }
+    manager = WorldManager(world)
+    manager.get_depth_of_node = lambda _nid: 6
+    nodes_updated, _ = manager.validate_world_data()
+    assert nodes_updated > 0
+    node = world["nodes"]["1"]
+    assert "tunnland" in node
+    assert "hunters" in node and node["hunters"] == 0
+    assert "gamekeeper_id" in node
+
+
 def test_update_neighbors_for_node_bidirectional():
     world = {
         "nodes": {


### PR DESCRIPTION
## Summary
- support new `Jaktmark` resource category
- allow only `Jägarmästare` characters
- track `hunters` and `gamekeeper_id` for Jaktmark nodes
- adjust UI to edit Jaktmark resources
- update validation logic and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883716a6a40832e8a41675af1c10d07