### PR TITLE
Add tests for utilities and data manager

### DIFF
--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -1,0 +1,65 @@
+import json
+from src import data_manager
+
+
+def test_load_worlds_from_file_success(tmp_path, monkeypatch):
+    data = {"a": 1}
+    f = tmp_path / "worlds.json"
+    f.write_text(json.dumps(data), encoding="utf-8")
+    monkeypatch.setattr(data_manager, "DEFAULT_WORLDS_FILE", str(f))
+    called = []
+    monkeypatch.setattr(data_manager.messagebox, "showerror", lambda *a, **k: called.append(True))
+    result = data_manager.load_worlds_from_file()
+    assert result == data
+    assert not called
+
+
+def test_load_worlds_from_file_missing(tmp_path, monkeypatch):
+    f = tmp_path / "missing.json"
+    monkeypatch.setattr(data_manager, "DEFAULT_WORLDS_FILE", str(f))
+    called = []
+    monkeypatch.setattr(data_manager.messagebox, "showerror", lambda *a, **k: called.append(True))
+    result = data_manager.load_worlds_from_file()
+    assert result == {}
+    assert not called
+
+
+def test_load_worlds_from_file_error(tmp_path, monkeypatch):
+    f = tmp_path / "bad.json"
+    f.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(data_manager, "DEFAULT_WORLDS_FILE", str(f))
+    def bad_load(_):
+        raise ValueError("boom")
+    monkeypatch.setattr(data_manager.WorldInterface, "load_worlds_file", bad_load)
+    called = []
+    monkeypatch.setattr(data_manager.messagebox, "showerror", lambda *a, **k: called.append(True))
+    result = data_manager.load_worlds_from_file()
+    assert result == {}
+    assert called
+
+
+def test_save_worlds_to_file_success(tmp_path, monkeypatch):
+    f = tmp_path / "out.json"
+    monkeypatch.setattr(data_manager, "DEFAULT_WORLDS_FILE", str(f))
+    saved = {}
+    def fake_save(data, path):
+        saved["data"] = data
+        saved["path"] = path
+    monkeypatch.setattr(data_manager.WorldInterface, "save_worlds_file", fake_save)
+    called = []
+    monkeypatch.setattr(data_manager.messagebox, "showerror", lambda *a, **k: called.append(True))
+    data_manager.save_worlds_to_file({"x": 2})
+    assert saved == {"data": {"x": 2}, "path": str(f)}
+    assert not called
+
+
+def test_save_worlds_to_file_error(tmp_path, monkeypatch):
+    f = tmp_path / "out.json"
+    monkeypatch.setattr(data_manager, "DEFAULT_WORLDS_FILE", str(f))
+    def bad_save(data, path):
+        raise IOError("fail")
+    monkeypatch.setattr(data_manager.WorldInterface, "save_worlds_file", bad_save)
+    called = []
+    monkeypatch.setattr(data_manager.messagebox, "showerror", lambda *a, **k: called.append(True))
+    data_manager.save_worlds_to_file({})
+    assert called

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,3 +45,18 @@ def test_generate_character_name_deterministic():
     female = utils.generate_character_name("f")
     assert male == "Mate Alen"
     assert female == "Mianeni Alen"
+
+
+def test_parse_int_10_valid_and_invalid():
+    class Bad:
+        def __str__(self):
+            raise RuntimeError("boom")
+
+    assert utils.parse_int_10("42") == 42
+    assert utils.parse_int_10(" 7 ") == 7
+    assert utils.parse_int_10(5) == 5
+    assert utils.parse_int_10("abc") == 0
+    assert utils.parse_int_10("") == 0
+    assert utils.parse_int_10(None) == 0
+    # Object raising in __str__ should yield 0
+    assert utils.parse_int_10(Bad()) == 0

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -231,3 +231,36 @@ def test_population_totals_refresh_after_edit():
     manager.update_population_totals()
     assert world["nodes"]["2"]["population"] == 5
     assert world["nodes"]["1"]["population"] == 5
+
+
+def test_set_border_between_updates_both_nodes():
+    world = {
+        "nodes": {
+            "1": {
+                "node_id": 1,
+                "parent_id": None,
+                "neighbors": [{"id": 2, "border": NEIGHBOR_NONE_STR}] + [{"id": None, "border": NEIGHBOR_NONE_STR}] * (MAX_NEIGHBORS - 1),
+            },
+            "2": {
+                "node_id": 2,
+                "parent_id": None,
+                "neighbors": [{"id": 1, "border": NEIGHBOR_NONE_STR}] + [{"id": None, "border": NEIGHBOR_NONE_STR}] * (MAX_NEIGHBORS - 1),
+            },
+        },
+        "characters": {},
+    }
+
+    manager = WorldManager(world)
+
+    changed = manager.set_border_between(1, 2, "v\u00e4g")
+    assert changed
+    assert world["nodes"]["1"]["neighbors"][0]["border"] == "v\u00e4g"
+    assert world["nodes"]["2"]["neighbors"][0]["border"] == "v\u00e4g"
+
+    changed = manager.set_border_between(1, 2, "v\u00e4g")
+    assert not changed
+
+    changed = manager.set_border_between(1, 2, "bogus")
+    assert changed
+    assert world["nodes"]["1"]["neighbors"][0]["border"] == NEIGHBOR_NONE_STR
+    assert world["nodes"]["2"]["neighbors"][0]["border"] == NEIGHBOR_NONE_STR


### PR DESCRIPTION
## Summary
- add coverage for `parse_int_10`
- add tests for `load_worlds_from_file` and `save_worlds_to_file`
- verify border updates with `set_border_between`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68849ecd575483229bf1f821ee811953