### PR TITLE
Implement Gods resource basics

### DIFF
--- a/src/node.py
+++ b/src/node.py
@@ -47,6 +47,13 @@ class Node:
     total_land: int = 0  # Total land area for 'Mark' resources
     forest_land: int = 0
     cleared_land: int = 0
+    manor_land: int = 0  # Total land area for 'Gods' resources
+    cultivated_land: int = 0
+    cultivated_quality: int = 3
+    fallow_land: int = 0
+    has_herd: bool = False
+    hunt_quality: int = 3
+    hunting_law: int = 0
     craftsmen: List[dict] = field(default_factory=list)
     soldiers: List[dict] = field(default_factory=list)
     characters: List[dict] = field(default_factory=list)
@@ -101,6 +108,28 @@ class Node:
         total_land = int(data.get("total_land", 0) or 0)
         forest_land = int(data.get("forest_land", 0) or 0)
         cleared_land = int(data.get("cleared_land", 0) or 0)
+        manor_land = int(data.get("manor_land", 0) or 0)
+        cultivated_land = int(data.get("cultivated_land", 0) or 0)
+        try:
+            cultivated_quality = int(data.get("cultivated_quality", 3) or 3)
+        except (ValueError, TypeError):
+            cultivated_quality = 3
+        cultivated_quality = max(1, min(cultivated_quality, 5))
+        fallow_land = int(data.get("fallow_land", 0) or 0)
+        herd_raw = data.get("has_herd", False)
+        if isinstance(herd_raw, str):
+            herd_raw = herd_raw.lower() in {"true", "1", "yes", "ja"}
+        has_herd = bool(herd_raw)
+        try:
+            hunt_quality = int(data.get("hunt_quality", 3) or 3)
+        except (ValueError, TypeError):
+            hunt_quality = 3
+        hunt_quality = max(1, min(hunt_quality, 5))
+        try:
+            hunting_law = int(data.get("hunting_law", 0) or 0)
+        except (ValueError, TypeError):
+            hunting_law = 0
+        hunting_law = max(0, min(hunting_law, 20))
         base_pop = int(data.get("population", 0) or 0)
         computed_pop = free_peasants + unfree_peasants + thralls + burghers
         res_type_raw = data.get("res_type", "Resurs")
@@ -228,6 +257,13 @@ class Node:
             total_land=total_land,
             forest_land=forest_land,
             cleared_land=cleared_land,
+            manor_land=manor_land,
+            cultivated_land=cultivated_land,
+            cultivated_quality=cultivated_quality,
+            fallow_land=fallow_land,
+            has_herd=has_herd,
+            hunt_quality=hunt_quality,
+            hunting_law=hunting_law,
             craftsmen=craftsmen,
             soldiers=soldiers,
             characters=characters,
@@ -309,6 +345,20 @@ class Node:
         if self.res_type == "Jaktmark":
             data["hunters"] = self.hunters
             data["gamekeeper_id"] = self.gamekeeper_id
+
+        if self.res_type == "Gods":
+            data.update(
+                {
+                    "manor_land": self.manor_land,
+                    "cultivated_land": self.cultivated_land,
+                    "cultivated_quality": self.cultivated_quality,
+                    "fallow_land": self.fallow_land,
+                    "has_herd": self.has_herd,
+                    "forest_land": self.forest_land,
+                    "hunt_quality": self.hunt_quality,
+                    "hunting_law": self.hunting_law,
+                }
+            )
 
         return data
 

--- a/src/world_interface.py
+++ b/src/world_interface.py
@@ -212,6 +212,45 @@ class WorldInterface(ABC):
                         if key not in node:
                             node[key] = 0
                             updated = True
+                elif res_type == "Gods":
+                    defaults = {
+                        "manor_land": 0,
+                        "cultivated_land": 0,
+                        "cultivated_quality": 3,
+                        "fallow_land": 0,
+                        "has_herd": False,
+                        "forest_land": 0,
+                        "hunt_quality": 3,
+                        "hunting_law": 0,
+                    }
+                    for key, val in defaults.items():
+                        if key not in node:
+                            node[key] = val
+                            updated = True
+                    try:
+                        cq = int(node.get("cultivated_quality", 3))
+                    except (ValueError, TypeError):
+                        cq = 3
+                    cq = max(1, min(cq, 5))
+                    if node.get("cultivated_quality") != cq:
+                        node["cultivated_quality"] = cq
+                        updated = True
+                    try:
+                        hq = int(node.get("hunt_quality", 3))
+                    except (ValueError, TypeError):
+                        hq = 3
+                    hq = max(1, min(hq, 5))
+                    if node.get("hunt_quality") != hq:
+                        node["hunt_quality"] = hq
+                        updated = True
+                    try:
+                        hl = int(node.get("hunting_law", 0))
+                    except (ValueError, TypeError):
+                        hl = 0
+                    hl = max(0, min(hl, 20))
+                    if node.get("hunting_law") != hl:
+                        node["hunting_law"] = hl
+                        updated = True
                 elif res_type == "Jaktmark":
                     if "tunnland" not in node:
                         node["tunnland"] = 0
@@ -223,7 +262,18 @@ class WorldInterface(ABC):
                         node["gamekeeper_id"] = None
                         updated = True
                 else:
-                    for key in ("total_land", "forest_land", "cleared_land"):
+                    for key in (
+                        "total_land",
+                        "forest_land",
+                        "cleared_land",
+                        "manor_land",
+                        "cultivated_land",
+                        "cultivated_quality",
+                        "fallow_land",
+                        "has_herd",
+                        "hunt_quality",
+                        "hunting_law",
+                    ):
                         if key in node:
                             del node[key]
                             updated = True

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -285,6 +285,42 @@ def test_node_mark_land_roundtrip():
     assert back["cleared_land"] == 5
 
 
+def test_node_gods_roundtrip():
+    raw = {
+        "node_id": 80,
+        "parent_id": 1,
+        "res_type": "Gods",
+        "manor_land": 100,
+        "cultivated_land": 60,
+        "cultivated_quality": 4,
+        "fallow_land": 20,
+        "has_herd": True,
+        "forest_land": 20,
+        "hunt_quality": 5,
+        "hunting_law": 2,
+    }
+
+    node = Node.from_dict(raw)
+    assert node.manor_land == 100
+    assert node.cultivated_land == 60
+    assert node.cultivated_quality == 4
+    assert node.fallow_land == 20
+    assert node.has_herd is True
+    assert node.forest_land == 20
+    assert node.hunt_quality == 5
+    assert node.hunting_law == 2
+
+    back = node.to_dict()
+    assert back["manor_land"] == 100
+    assert back["cultivated_land"] == 60
+    assert back["cultivated_quality"] == 4
+    assert back["fallow_land"] == 20
+    assert back["has_herd"] is True
+    assert back["forest_land"] == 20
+    assert back["hunt_quality"] == 5
+    assert back["hunting_law"] == 2
+
+
 def test_node_water_fields_roundtrip():
     raw = {
         "node_id": 70,

--- a/tests/test_world_interface.py
+++ b/tests/test_world_interface.py
@@ -168,6 +168,21 @@ def test_validate_world_data_jaktmark_defaults():
     assert "gamekeeper_id" in node
 
 
+def test_validate_world_data_gods_defaults():
+    world = {
+        "nodes": {"1": {"node_id": 1, "parent_id": None, "res_type": "Gods"}},
+        "characters": {},
+    }
+    manager = WorldManager(world)
+    manager.get_depth_of_node = lambda _nid: 5
+    nodes_updated, _ = manager.validate_world_data()
+    assert nodes_updated > 0
+    node = world["nodes"]["1"]
+    assert "manor_land" in node
+    assert "cultivated_quality" in node and node["cultivated_quality"] == 3
+    assert "hunt_quality" in node and node["hunt_quality"] == 3
+
+
 def test_update_neighbors_for_node_bidirectional():
     world = {
         "nodes": {


### PR DESCRIPTION
## Summary
- add new fields for `Gods` resource type
- support saving/loading of Gods fields
- validate Gods nodes in `WorldInterface`
- test Node and WorldInterface with Gods nodes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887e7d26938832eaccbf286188e8f81