### PR TITLE
Fix population rollup from settlement children

### DIFF
--- a/src/world_manager.py
+++ b/src/world_manager.py
@@ -79,6 +79,18 @@ class WorldManager(WorldInterface):
             nodes[str(nid)]["population"] = base_pop
 
         # Now accumulate child populations from deepest level upwards
+        parent_lookup: Dict[int, List[int]] = {}
+        for cid_str, cdata in nodes.items():
+            try:
+                cid = int(cid_str)
+            except ValueError:
+                continue
+            pid = cdata.get("parent_id")
+            if isinstance(pid, str) and pid.isdigit():
+                pid = int(pid)
+            if isinstance(pid, int):
+                parent_lookup.setdefault(pid, []).append(cid)
+
         for depth in range(max_depth, -1, -1):
             for nid, d in depth_map.items():
                 if d != depth:
@@ -87,7 +99,9 @@ class WorldManager(WorldInterface):
                 if not node:
                     continue
                 total = base_population.get(nid, 0)
-                for cid in node.get("children", []):
+                child_ids = set(node.get("children", []))
+                child_ids.update(parent_lookup.get(nid, []))
+                for cid in child_ids:
                     child = nodes.get(str(cid))
                     if not child:
                         continue

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -264,3 +264,29 @@ def test_set_border_between_updates_both_nodes():
     assert changed
     assert world["nodes"]["1"]["neighbors"][0]["border"] == NEIGHBOR_NONE_STR
     assert world["nodes"]["2"]["neighbors"][0]["border"] == NEIGHBOR_NONE_STR
+
+
+def test_population_totals_use_parent_links():
+    world = {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None, "children": [4]},
+            "4": {"node_id": 4, "parent_id": 1, "children": [], "res_type": "Gods"},
+            "5": {
+                "node_id": 5,
+                "parent_id": 4,
+                "children": [],
+                "res_type": "Bosättning",
+                "free_peasants": 6,
+            },
+        },
+        "characters": {},
+    }
+
+    manager = WorldManager(world)
+    manager.get_depth_of_node = lambda nid: {1: 0, 4: 1, 5: 2}[nid]
+
+    manager.update_population_totals()
+
+    assert world["nodes"]["5"]["population"] == 6
+    assert world["nodes"]["4"]["population"] == 6
+    assert world["nodes"]["1"]["population"] == 6


### PR DESCRIPTION
## Summary
- roll up population from nodes that reference a parent but are missing from the parent's `children` list
- test that population totals include such settlement nodes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f1e68088832eac91e39ab48fecc0