### PR TITLE
Remove population field from animal resources

### DIFF
--- a/src/dynamic_map.py
+++ b/src/dynamic_map.py
@@ -187,8 +187,11 @@ class DynamicMapCanvas:
     def show_node_tooltip(self, event, node: Node) -> None:
         """Display a small popup with information about ``node``."""
         display_name = self.simulator.get_display_name_for_node(node, 3)
-        population = node.calculate_population()
-        text = f"{display_name}\nBefolkning: {population}"
+        if node.res_type == "Djur":
+            text = display_name
+        else:
+            population = node.calculate_population()
+            text = f"{display_name}\nBefolkning: {population}"
         self._show_tooltip(event, text)
 
     def _show_tooltip(self, event, text: str) -> None:

--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -2083,6 +2083,11 @@ class FeodalSimulator:
                 area_entry.grid()
                 pop_label.grid_remove()
                 pop_entry.grid_remove()
+            elif res_var.get() == "Djur":
+                area_label.grid_remove()
+                area_entry.grid_remove()
+                pop_label.grid_remove()
+                pop_entry.grid_remove()
             else:
                 area_label.grid_remove()
                 area_entry.grid_remove()
@@ -2772,6 +2777,8 @@ class FeodalSimulator:
                 except (tk.TclError, ValueError):
                     node_data["tunnland"] = 0
                 temp_data["population"] = 0
+            elif res_var.get() == "Djur":
+                temp_data["population"] = 0
             else:
                 try:
                     manual_pop = int(pop_var.get() or "0")
@@ -2963,7 +2970,7 @@ class FeodalSimulator:
                 if r["type_var"].get()
             ]
 
-            if new_type == "Vildmark":
+            if new_type in {"Vildmark", "Djur"}:
                 new_pop = 0
             else:
                 new_pop = self.calculate_population_from_fields({
@@ -3061,6 +3068,9 @@ class FeodalSimulator:
             if new_type == "Djur":
                 if old_animals != new_animals:
                     node_data["animals"] = new_animals
+                    changes = True
+                if "population" in node_data:
+                    del node_data["population"]
                     changes = True
             else:
                 if "animals" in node_data:
@@ -3186,7 +3196,7 @@ class FeodalSimulator:
                 for r in building_rows
                 if r["type_var"].get()
             ]
-            if res_var.get() == "Vildmark":
+            if res_var.get() in {"Vildmark", "Djur"}:
                 new_pop = 0
             else:
                 new_pop = self.calculate_population_from_fields({

--- a/src/world_interface.py
+++ b/src/world_interface.py
@@ -128,6 +128,10 @@ class WorldInterface(ABC):
                     if key not in node:
                         node[key] = 0
                         updated = True
+            elif res_type == "Djur":
+                if "population" in node:
+                    del node["population"]
+                    updated = True
             else:
                 if "population" not in node:
                     node["population"] = 0
@@ -250,6 +254,10 @@ class WorldInterface(ABC):
                     hl = max(0, min(hl, 20))
                     if node.get("hunting_law") != hl:
                         node["hunting_law"] = hl
+                        updated = True
+                elif res_type == "Djur":
+                    if "population" in node:
+                        del node["population"]
                         updated = True
                 elif res_type == "Jaktmark":
                     if "tunnland" not in node:

--- a/tests/test_world_interface.py
+++ b/tests/test_world_interface.py
@@ -143,6 +143,7 @@ def test_validate_world_data_resource_fields_by_type():
     assert "soldiers" in node1 and node1["soldiers"] == []
     assert "animals" not in node1
     assert "animals" in node2 and node2["animals"] == []
+    assert "population" not in node2
     assert "soldiers" not in node2
     assert "soldiers" not in node3
     assert "animals" not in node3


### PR DESCRIPTION
## Summary
- hide population from animal nodes in the world interface
- skip population display on animal nodes in the map tooltip
- adjust resource editor logic for `Djur` resources
- update world data validation tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f5c0e218832eba699d9a7e820c7c