### PR TITLE
Fix population totals when loading world

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -547,6 +547,9 @@ class FeodalSimulator:
             )
             self.save_current_world()
 
+        # Ensure population totals are consistent upon load
+        self.world_manager.update_population_totals()
+
         # Load any saved static map positions
         self.load_static_positions()
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -211,6 +211,34 @@ def test_load_world_uses_saved_positions():
     assert sim.map_static_positions[20] == (5, 1)
 
 
+def test_load_world_updates_population_totals():
+    world = {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None, "children": [2]},
+            "2": {"node_id": 2, "parent_id": 1, "children": [3], "res_type": "Gods"},
+            "3": {
+                "node_id": 3,
+                "parent_id": 2,
+                "children": [],
+                "res_type": "Bosättning",
+                "free_peasants": 4,
+            },
+        },
+        "characters": {},
+    }
+    sim = LoadStubSimulator()
+    sim.world_manager = fs.WorldManager({})
+    sim.static_rows = 1
+    sim.static_cols = 1
+    sim.all_worlds = {"A": world}
+
+    fs.FeodalSimulator.load_world(sim, "A")
+
+    assert sim.world_data["nodes"]["1"]["population"] == 4
+    assert sim.world_data["nodes"]["2"]["population"] == 4
+    assert sim.world_data["nodes"]["3"]["population"] == 4
+
+
 def test_auto_link_adjacent_hexes_adds_neighbors():
     world = {
         "nodes": {


### PR DESCRIPTION
## Summary
- recompute population totals in `load_world`
- test that `load_world` updates populations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ff477454832e8361b62b64d579e9