### PR TITLE
Remove population field for Estate nodes

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -2111,7 +2111,7 @@ class FeodalSimulator:
                 area_entry.grid()
                 pop_label.grid_remove()
                 pop_entry.grid_remove()
-            elif res_var.get() == "Djur":
+            elif res_var.get() in {"Djur", "Gods"}:
                 area_label.grid_remove()
                 area_entry.grid_remove()
                 pop_label.grid_remove()


### PR DESCRIPTION
## Summary
- hide the population entry when editing a resource node of type "Gods"

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a90acf144832ea6cd9982239293c1