### PR TITLE
Add dagsverken field and work calc

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -106,8 +106,17 @@ DAGSVERKEN_LEVELS = [
     "få",
     "normalt",
     "många",
-    "galet många",
+    "tyranniskt många",
 ]
+
+# Mapping from dagsverken level to work days per unfree peasant
+DAGSVERKEN_MULTIPLIERS = {
+    "inga": 0,
+    "få": 40,
+    "normalt": 80,
+    "många": 100,
+    "tyranniskt många": 120,
+}
 
 # Fish quality levels for sea and river resources
 FISH_QUALITY_LEVELS = [


### PR DESCRIPTION
## Summary
- update dagsverken levels and add multiplier constants
- show dagsverken dropdown when editing settlements
- adjust unsaved checks and save logic
- calculate jarldom work available based on unfree peasants and thralls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b895ac634832eb7f0a709192644d8