### PR TITLE
Add menu links for managing worlds and characters

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -86,6 +86,11 @@ class FeodalSimulator:
         file_menu.add_command(label="Avsluta", command=self.root.quit)
         menubar.add_cascade(label="Arkiv", menu=file_menu)
 
+        edit_menu = tk.Menu(menubar, tearoff=0)
+        edit_menu.add_command(label="Hantera världar", command=self.show_manage_worlds_view)
+        edit_menu.add_command(label="Hantera karaktärer", command=self.show_manage_characters_view)
+        menubar.add_cascade(label="Ändra", menu=edit_menu)
+
         about_menu = tk.Menu(menubar, tearoff=0)
         about_menu.add_command(label="Programmet", command=self.show_about_program)
         menubar.add_cascade(label="Om", menu=about_menu)


### PR DESCRIPTION
## Summary
- Add new "Ändra" menu to main menu bar
- Provide quick access to "Hantera världar" and "Hantera karaktärer" views

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f1a75fa508322975a5ab1503b6b3b