### PR TITLE
Restrict weather nodes to fixed name and no subnodes

### DIFF
--- a/src/node.py
+++ b/src/node.py
@@ -256,7 +256,7 @@ class Node:
             node_id=node_id,
             parent_id=parent_id,
             name=data.get("name", ""),
-            custom_name=data.get("custom_name", ""),
+            custom_name=data.get("custom_name", "") if res_type != "Väder" else "",
             population=population,
             ruler_id=ruler_id,
             num_subfiefs=int(data.get("num_subfiefs", 0)),
@@ -368,6 +368,7 @@ class Node:
             data["gamekeeper_id"] = self.gamekeeper_id
 
         if self.res_type == "Väder":
+            data.pop("custom_name", None)
             for key in [
                 "population",
                 "settlement_type",

--- a/src/world_manager.py
+++ b/src/world_manager.py
@@ -357,7 +357,7 @@ class WorldManager(WorldInterface):
             parts: List[str] = []
             if res_type and res_type != "Resurs":
                 parts.append(res_type)
-            if custom_name:
+            if custom_name and res_type != "Väder":
                 parts.append(custom_name)
             if ruler_str:
                 parts.append(f"({ruler_str})")
@@ -378,6 +378,10 @@ class WorldManager(WorldInterface):
 
     def update_subfiefs_for_node(self, node_data: Dict[str, Any]) -> None:
         current_children_ids = set(node_data.get("children", []))
+        if node_data.get("res_type") == "Väder":
+            node_data["children"] = []
+            node_data["num_subfiefs"] = 0
+            return
         target_count = node_data.get("num_subfiefs", 0)
         depth = self.get_depth_of_node(node_data["node_id"])
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -389,3 +389,20 @@ def test_node_res_type_invalid_defaults_to_resurs():
 
     back = node.to_dict()
     assert back["res_type"] == "Resurs"
+
+
+def test_weather_node_clears_custom_name():
+    raw = {
+        "node_id": 99,
+        "parent_id": 1,
+        "res_type": "Väder",
+        "custom_name": "Storm",
+        "spring_weather": "Soligt",
+    }
+
+    node = Node.from_dict(raw)
+    assert node.custom_name == ""
+
+    back = node.to_dict()
+    assert "custom_name" not in back
+    assert back["spring_weather"] == "Soligt"

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -318,3 +318,24 @@ def test_population_totals_use_parent_links():
     assert world["nodes"]["5"]["population"] == 6
     assert world["nodes"]["4"]["population"] == 6
     assert world["nodes"]["1"]["population"] == 6
+
+
+def test_update_subfiefs_skips_weather_nodes():
+    world = {
+        "nodes": {
+            "1": {
+                "node_id": 1,
+                "parent_id": None,
+                "children": [],
+                "res_type": "Väder",
+                "num_subfiefs": 3,
+            }
+        },
+        "characters": {},
+    }
+
+    manager = WorldManager(world)
+    manager.update_subfiefs_for_node(world["nodes"]["1"])
+
+    assert world["nodes"]["1"]["children"] == []
+    assert world["nodes"]["1"]["num_subfiefs"] == 0


### PR DESCRIPTION
## Summary
- Remove custom-name support for weather resources
- Disallow creating child nodes under weather resources
- Shrink weather effect input field and add tests for weather nodes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68951a58a6cc832eb7a5f4db3c4c19de