### PR TITLE
Implement weather roll and enforce single weather node

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -45,15 +45,15 @@ JARLDOM_RESOURCE_TYPES = [
 
 # Weather options used for Väder nodes
 WEATHER_OPTIONS = [
-    "Normalt väder",
-    "Soligt",
-    "Regnigt",
-    "Stormigt",
-    "Torka",
-    "Värmebölja",
-    "Kallt",
-    "Snöfall",
-    "Dimma",
+    "Ödeläggelse",
+    "Storm",
+    "Oväder",
+    "Ostadighet",
+    "Normalväder",
+    "Gynnsamhet",
+    "Solsken",
+    "Fruktbarhet",
+    "Mirakelväder",
 ]
 
 # Categorized for easier handling in UI

--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -13,7 +13,6 @@ from constants import (
     NEIGHBOR_NONE_STR,
     NEIGHBOR_OTHER_STR,
     MAX_NEIGHBORS,
-    JARLDOM_RESOURCE_TYPES,
     SETTLEMENT_TYPES,
     CRAFTSMAN_TYPES,
     BUILDING_TYPES,
@@ -33,6 +32,7 @@ from utils import (
     generate_swedish_village_name,
     generate_character_name,
     ScrollableFrame,
+    available_resource_types,
 )
 from dynamic_map import DynamicMapCanvas
 from map_logic import StaticMapLogic
@@ -1967,9 +1967,11 @@ class FeodalSimulator:
         """Editor for resource nodes at depth >=4."""
         node_id = node_data["node_id"]
 
-        # Ensure res_type exists
-        if "res_type" not in node_data or not node_data["res_type"]:
-            node_data["res_type"] = JARLDOM_RESOURCE_TYPES[0]
+        res_options = available_resource_types(self.world_data, node_id)
+        initial_res_type = node_data.get("res_type")
+        if not initial_res_type or initial_res_type not in res_options:
+            initial_res_type = res_options[0]
+            node_data["res_type"] = initial_res_type
 
         editor_frame = ttk.Frame(parent_frame)
         editor_frame.pack(fill="both", expand=True)
@@ -1979,8 +1981,8 @@ class FeodalSimulator:
         row_idx = 0
 
         ttk.Label(editor_frame, text="Resurstyp:").grid(row=row_idx, column=0, sticky="w", padx=5, pady=3)
-        res_var = tk.StringVar(value=node_data.get("res_type", JARLDOM_RESOURCE_TYPES[0]))
-        res_combo = ttk.Combobox(editor_frame, textvariable=res_var, values=JARLDOM_RESOURCE_TYPES, state="readonly")
+        res_var = tk.StringVar(value=initial_res_type)
+        res_combo = ttk.Combobox(editor_frame, textvariable=res_var, values=res_options, state="readonly")
         res_combo.grid(row=row_idx, column=1, sticky="w", padx=5, pady=3)
         save_button = ttk.Button(editor_frame, text="Spara Nod")
         save_button.grid(row=row_idx, column=2, sticky="w", padx=5, pady=3)
@@ -2013,7 +2015,7 @@ class FeodalSimulator:
         row_idx += 1
 
         spring_label = ttk.Label(editor_frame, text="Vårväder:")
-        spring_var = tk.StringVar(value=node_data.get("spring_weather", "Normalt väder"))
+        spring_var = tk.StringVar(value=node_data.get("spring_weather", "Normalväder"))
         spring_combo = ttk.Combobox(
             editor_frame, textvariable=spring_var, values=WEATHER_OPTIONS, state="readonly"
         )
@@ -2022,7 +2024,7 @@ class FeodalSimulator:
         row_idx += 1
 
         summer_label = ttk.Label(editor_frame, text="Sommarväder:")
-        summer_var = tk.StringVar(value=node_data.get("summer_weather", "Normalt väder"))
+        summer_var = tk.StringVar(value=node_data.get("summer_weather", "Normalväder"))
         summer_combo = ttk.Combobox(
             editor_frame, textvariable=summer_var, values=WEATHER_OPTIONS, state="readonly"
         )
@@ -2031,7 +2033,7 @@ class FeodalSimulator:
         row_idx += 1
 
         autumn_label = ttk.Label(editor_frame, text="Höstväder:")
-        autumn_var = tk.StringVar(value=node_data.get("autumn_weather", "Normalt väder"))
+        autumn_var = tk.StringVar(value=node_data.get("autumn_weather", "Normalväder"))
         autumn_combo = ttk.Combobox(
             editor_frame, textvariable=autumn_var, values=WEATHER_OPTIONS, state="readonly"
         )
@@ -2040,7 +2042,7 @@ class FeodalSimulator:
         row_idx += 1
 
         winter_label = ttk.Label(editor_frame, text="Vinterväder:")
-        winter_var = tk.StringVar(value=node_data.get("winter_weather", "Normalt väder"))
+        winter_var = tk.StringVar(value=node_data.get("winter_weather", "Normalväder"))
         winter_combo = ttk.Combobox(
             editor_frame, textvariable=winter_var, values=WEATHER_OPTIONS, state="readonly"
         )
@@ -2985,10 +2987,10 @@ class FeodalSimulator:
             old_forest = int(node_data.get("forest_land", 0))
             old_hq = int(node_data.get("hunt_quality", 3))
             old_law = int(node_data.get("hunting_law", 0))
-            old_spring = node_data.get("spring_weather", "Normalt väder")
-            old_summer = node_data.get("summer_weather", "Normalt väder")
-            old_autumn = node_data.get("autumn_weather", "Normalt väder")
-            old_winter = node_data.get("winter_weather", "Normalt väder")
+            old_spring = node_data.get("spring_weather", "Normalväder")
+            old_summer = node_data.get("summer_weather", "Normalväder")
+            old_autumn = node_data.get("autumn_weather", "Normalväder")
+            old_winter = node_data.get("winter_weather", "Normalväder")
             old_weather_effect = node_data.get("weather_effect", "")
             
             def calc_work(level: str, unfree: int, thralls: int) -> int:
@@ -3524,7 +3526,7 @@ class FeodalSimulator:
                 })
 
             return (
-                res_var.get().strip() != node_data.get("res_type", JARLDOM_RESOURCE_TYPES[0])
+                res_var.get().strip() != initial_res_type
                 or custom_var.get().strip() != node_data.get("custom_name", "")
                 or (res_var.get() not in {"Vildmark", "Jaktmark"} and new_pop != node_data.get("population", 0))
                 or (res_var.get() in {"Vildmark", "Jaktmark"} and manual_area != node_data.get("tunnland", 0))
@@ -3555,10 +3557,10 @@ class FeodalSimulator:
                 or (
                     res_var.get() == "Väder"
                     and (
-                        new_spring != node_data.get("spring_weather", "Normalt väder")
-                        or new_summer != node_data.get("summer_weather", "Normalt väder")
-                        or new_autumn != node_data.get("autumn_weather", "Normalt väder")
-                        or new_winter != node_data.get("winter_weather", "Normalt väder")
+                        new_spring != node_data.get("spring_weather", "Normalväder")
+                        or new_summer != node_data.get("summer_weather", "Normalväder")
+                        or new_autumn != node_data.get("autumn_weather", "Normalväder")
+                        or new_winter != node_data.get("winter_weather", "Normalväder")
                         or new_weather_effect != node_data.get("weather_effect", "")
                     )
                 )

--- a/src/node.py
+++ b/src/node.py
@@ -63,10 +63,10 @@ class Node:
     fishing_boats: int = 0
     hunters: int = 0
     gamekeeper_id: Optional[int] = None
-    spring_weather: str = "Normalt väder"
-    summer_weather: str = "Normalt väder"
-    autumn_weather: str = "Normalt väder"
-    winter_weather: str = "Normalt väder"
+    spring_weather: str = "Normalväder"
+    summer_weather: str = "Normalväder"
+    autumn_weather: str = "Normalväder"
+    winter_weather: str = "Normalväder"
     weather_effect: str = ""
 
     @classmethod
@@ -206,10 +206,10 @@ class Node:
             gamekeeper_id = int(gamekeeper_id)
         elif gamekeeper_id is not None and not isinstance(gamekeeper_id, int):
             gamekeeper_id = None
-        spring_weather = data.get("spring_weather", "Normalt väder")
-        summer_weather = data.get("summer_weather", "Normalt väder")
-        autumn_weather = data.get("autumn_weather", "Normalt väder")
-        winter_weather = data.get("winter_weather", "Normalt väder")
+        spring_weather = data.get("spring_weather", "Normalväder")
+        summer_weather = data.get("summer_weather", "Normalväder")
+        autumn_weather = data.get("autumn_weather", "Normalväder")
+        winter_weather = data.get("winter_weather", "Normalväder")
         weather_effect = data.get("weather_effect", "")
         if res_type in {"Hav", "Flod"}:
             wq_raw = data.get("fish_quality", data.get("water_quality", "Normalt"))

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,6 +3,8 @@ import random
 import tkinter as tk
 from tkinter import ttk
 
+from constants import JARLDOM_RESOURCE_TYPES
+
 
 def parse_int_10(value: str | int | None) -> int:
     """Return ``value`` parsed as a base-10 integer or 0 on failure."""
@@ -92,6 +94,25 @@ def roll_dice(expr: str, debug=False):
         dbg = f"Slår OB{dice_count}D{die_type} => [{dbg_rolls}] + {plus_mod} = {total}"
         return total, dbg
     return total, ""
+
+
+def available_resource_types(world_data: dict | None, current_node_id: int | None = None) -> list[str]:
+    """Return allowed resource types, hiding ``Väder`` if already in use."""
+    options = list(JARLDOM_RESOURCE_TYPES)
+    if not world_data:
+        return options
+    nodes = world_data.get("nodes", {})
+    for nid, ndata in nodes.items():
+        if ndata.get("res_type") == "Väder":
+            try:
+                if current_node_id is None or int(nid) != int(current_node_id):
+                    options = [o for o in options if o != "Väder"]
+                    break
+            except Exception:
+                if current_node_id is None or str(nid) != str(current_node_id):
+                    options = [o for o in options if o != "Väder"]
+                    break
+    return options
 
 
 def generate_swedish_village_name() -> str:

--- a/src/weather.py
+++ b/src/weather.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+import random
+
+
+@dataclass(frozen=True)
+class WeatherType:
+    """Represents a weather category and its mechanical effects."""
+
+    name: str
+    production_percent: int
+    hardship_modifier: int
+    affected_industries: int
+
+
+# Table mapping roll ranges to weather types.
+# Each entry is (min_roll, max_roll, WeatherType)
+WEATHER_TABLE = [
+    (float("-inf"), 1, WeatherType("Ödeläggelse", -25, 3, 4)),
+    (2, 2, WeatherType("Storm", -15, 2, 3)),
+    (3, 3, WeatherType("Oväder", -10, 2, 2)),
+    (4, 4, WeatherType("Ostadighet", -5, 1, 1)),
+    (5, 9, WeatherType("Normalväder", 0, 0, 0)),
+    (10, 10, WeatherType("Gynnsamhet", 1, -1, 1)),
+    (11, 11, WeatherType("Solsken", 2, -1, 2)),
+    (12, 12, WeatherType("Fruktbarhet", 4, -2, 3)),
+    (13, float("inf"), WeatherType("Mirakelväder", 8, -3, 4)),
+]
+
+
+def determine_weather_type(total: int) -> WeatherType:
+    """Return the WeatherType corresponding to ``total``."""
+    for low, high, wtype in WEATHER_TABLE:
+        if low <= total <= high:
+            return wtype
+    # Fallback, should never happen
+    return WeatherType("Normalväder", 0, 0, 0)
+
+
+def roll_weather(modifier: int = 0) -> tuple[int, WeatherType]:
+    """Roll 2d6, apply ``modifier`` and return the resulting WeatherType."""
+    roll = random.randint(1, 6) + random.randint(1, 6)
+    total = roll + modifier
+    wtype = determine_weather_type(total)
+    return total, wtype

--- a/src/world_interface.py
+++ b/src/world_interface.py
@@ -271,10 +271,10 @@ class WorldInterface(ABC):
                         updated = True
                 elif res_type == "Väder":
                     defaults = {
-                        "spring_weather": "Normalt väder",
-                        "summer_weather": "Normalt väder",
-                        "autumn_weather": "Normalt väder",
-                        "winter_weather": "Normalt väder",
+                        "spring_weather": "Normalväder",
+                        "summer_weather": "Normalväder",
+                        "autumn_weather": "Normalväder",
+                        "winter_weather": "Normalväder",
                         "weather_effect": "",
                     }
                     for key, val in defaults.items():

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -397,7 +397,7 @@ def test_weather_node_clears_custom_name():
         "parent_id": 1,
         "res_type": "Väder",
         "custom_name": "Storm",
-        "spring_weather": "Soligt",
+        "spring_weather": "Solsken",
     }
 
     node = Node.from_dict(raw)
@@ -405,4 +405,4 @@ def test_weather_node_clears_custom_name():
 
     back = node.to_dict()
     assert "custom_name" not in back
-    assert back["spring_weather"] == "Soligt"
+    assert back["spring_weather"] == "Solsken"

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+from utils import available_resource_types
+from weather import roll_weather
+
+
+def test_available_resource_types_excludes_weather():
+    world = {"nodes": {"1": {"node_id": 1, "res_type": "Väder"}}}
+    opts = available_resource_types(world, current_node_id=2)
+    assert "Väder" not in opts
+    opts_current = available_resource_types(world, current_node_id=1)
+    assert "Väder" in opts_current
+
+
+def test_roll_weather_table():
+    with patch("random.randint", side_effect=[1, 1]):
+        total, w = roll_weather(modifier=-2)
+    assert total == 0
+    assert w.name == "Ödeläggelse"
+
+    with patch("random.randint", side_effect=[6, 6]):
+        total, w = roll_weather()
+    assert total == 12
+    assert w.name == "Fruktbarhet"
+
+    with patch("random.randint", side_effect=[6, 6]):
+        total, w = roll_weather(modifier=2)
+    assert total == 14
+    assert w.name == "Mirakelväder"


### PR DESCRIPTION
## Summary
- Define weather table and 2D6-based roll to determine weather effects
- Update constants and defaults to new weather types
- Hide `Väder` resource type when another weather node exists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689520ad7564832e99517e24c7709382