### PR TITLE
Hide weather randomization for non-weather nodes

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -2378,6 +2378,7 @@ class FeodalSimulator:
                 winter_combo,
                 weather_effect_label,
                 weather_effect_entry,
+                slump_button,
             ]
             if res_var.get() == "Väder":
                 for w in widgets:


### PR DESCRIPTION
## Summary
- Hide the "Slumpa" weather randomization button unless the node is a weather resource

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689526a30664832e9a360d99ddeef1b4