### PR TITLE
Add seasonal weather tables with roll display

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -43,19 +43,6 @@ JARLDOM_RESOURCE_TYPES = [
     "Väder",
 ]
 
-# Weather options used for Väder nodes
-WEATHER_OPTIONS = [
-    "Ödeläggelse",
-    "Storm",
-    "Oväder",
-    "Ostadighet",
-    "Normalväder",
-    "Gynnsamhet",
-    "Solsken",
-    "Fruktbarhet",
-    "Mirakelväder",
-]
-
 # Categorized for easier handling in UI
 AREAL_TYPES = {"Jaktmark", "Odlingsmark", "Betesmark", "Fiskevatten"}
 SOLDIER_TYPES = {

--- a/src/node.py
+++ b/src/node.py
@@ -8,6 +8,7 @@ from constants import (
     FISH_QUALITY_LEVELS,
     MAX_FISHING_BOATS,
 )
+from weather import NORMAL_WEATHER
 
 
 @dataclass
@@ -63,10 +64,10 @@ class Node:
     fishing_boats: int = 0
     hunters: int = 0
     gamekeeper_id: Optional[int] = None
-    spring_weather: str = "Normalväder"
-    summer_weather: str = "Normalväder"
-    autumn_weather: str = "Normalväder"
-    winter_weather: str = "Normalväder"
+    spring_weather: str = NORMAL_WEATHER["spring"]
+    summer_weather: str = NORMAL_WEATHER["summer"]
+    autumn_weather: str = NORMAL_WEATHER["autumn"]
+    winter_weather: str = NORMAL_WEATHER["winter"]
     weather_effect: str = ""
 
     @classmethod
@@ -206,10 +207,10 @@ class Node:
             gamekeeper_id = int(gamekeeper_id)
         elif gamekeeper_id is not None and not isinstance(gamekeeper_id, int):
             gamekeeper_id = None
-        spring_weather = data.get("spring_weather", "Normalväder")
-        summer_weather = data.get("summer_weather", "Normalväder")
-        autumn_weather = data.get("autumn_weather", "Normalväder")
-        winter_weather = data.get("winter_weather", "Normalväder")
+        spring_weather = data.get("spring_weather", NORMAL_WEATHER["spring"])
+        summer_weather = data.get("summer_weather", NORMAL_WEATHER["summer"])
+        autumn_weather = data.get("autumn_weather", NORMAL_WEATHER["autumn"])
+        winter_weather = data.get("winter_weather", NORMAL_WEATHER["winter"])
         weather_effect = data.get("weather_effect", "")
         if res_type in {"Hav", "Flod"}:
             wq_raw = data.get("fish_quality", data.get("water_quality", "Normalt"))

--- a/src/weather.py
+++ b/src/weather.py
@@ -12,33 +12,89 @@ class WeatherType:
     affected_industries: int
 
 
-# Table mapping roll ranges to weather types.
+# Season-specific tables mapping roll ranges to weather types.
 # Each entry is (min_roll, max_roll, WeatherType)
-WEATHER_TABLE = [
-    (float("-inf"), 1, WeatherType("Ödeläggelse", -25, 3, 4)),
-    (2, 2, WeatherType("Storm", -15, 2, 3)),
-    (3, 3, WeatherType("Oväder", -10, 2, 2)),
-    (4, 4, WeatherType("Ostadighet", -5, 1, 1)),
-    (5, 9, WeatherType("Normalväder", 0, 0, 0)),
-    (10, 10, WeatherType("Gynnsamhet", 1, -1, 1)),
-    (11, 11, WeatherType("Solsken", 2, -1, 2)),
-    (12, 12, WeatherType("Fruktbarhet", 4, -2, 3)),
-    (13, float("inf"), WeatherType("Mirakelväder", 8, -3, 4)),
+SPRING_WEATHER_TABLE = [
+    (float("-inf"), 1, WeatherType("Storm och hagel (+3)", -25, 3, 4)),
+    (2, 2, WeatherType("Våt och kall (+2)", -15, 2, 3)),
+    (3, 3, WeatherType("Sen vår (+2)", -10, 2, 2)),
+    (4, 4, WeatherType("Ostadig vår (+1)", -5, 1, 1)),
+    (5, 9, WeatherType("Normal vår (±0)", 0, 0, 0)),
+    (10, 10, WeatherType("Växlande sol (-1)", 1, -1, 1)),
+    (11, 11, WeatherType("Varmt och stabilt (-1)", 2, -1, 2)),
+    (12, 12, WeatherType("God växtkraft (-2)", 4, -2, 3)),
+    (13, float("inf"), WeatherType("Exceptionellt vårväder (-3)", 8, -3, 4)),
 ]
 
+SUMMER_WEATHER_TABLE = [
+    (float("-inf"), 1, WeatherType("Torka och storm (+3)", -25, 3, 4)),
+    (2, 2, WeatherType("Kvävande hetta (+2)", -15, 2, 3)),
+    (3, 3, WeatherType("Torka (+2)", -10, 2, 2)),
+    (4, 4, WeatherType("Nederbördsfattigt (+1)", -5, 1, 1)),
+    (5, 9, WeatherType("Normal sommar (±0)", 0, 0, 0)),
+    (10, 10, WeatherType("Måttlig värme (-1)", 1, -1, 1)),
+    (11, 11, WeatherType("Soligt med regn (-1)", 2, -1, 2)),
+    (12, 12, WeatherType("Stabil värme (-2)", 4, -2, 3)),
+    (13, float("inf"), WeatherType("Idealisk sommar (-3)", 8, -3, 4)),
+]
 
-def determine_weather_type(total: int) -> WeatherType:
-    """Return the WeatherType corresponding to ``total``."""
-    for low, high, wtype in WEATHER_TABLE:
+AUTUMN_WEATHER_TABLE = [
+    (float("-inf"), 1, WeatherType("Ihållande regn (+3)", -25, 3, 4)),
+    (2, 2, WeatherType("Tidig frost (+2)", -15, 2, 3)),
+    (3, 3, WeatherType("Regn och blåst (+2)", -10, 2, 2)),
+    (4, 4, WeatherType("Kyligt och blött (+1)", -5, 1, 1)),
+    (5, 9, WeatherType("Normal höst (±0)", 0, 0, 0)),
+    (10, 10, WeatherType("Lätt dimma (-1)", 1, -1, 1)),
+    (11, 11, WeatherType("Klar höstluft (-1)", 2, -1, 2)),
+    (12, 12, WeatherType("Soligt och torrt (-2)", 4, -2, 3)),
+    (13, float("inf"), WeatherType("Perfekt skördväder (-3)", 8, -3, 4)),
+]
+
+WINTER_WEATHER_TABLE = [
+    (float("-inf"), 1, WeatherType("Isstorm (+3)", -25, 3, 4)),
+    (2, 2, WeatherType("Djup snö (+2)", -15, 2, 3)),
+    (3, 3, WeatherType("Tidig snö (+2)", -10, 2, 2)),
+    (4, 4, WeatherType("Snöslask (+1)", -5, 1, 1)),
+    (5, 9, WeatherType("Normal vinter (±0)", 0, 0, 0)),
+    (10, 10, WeatherType("Mild kyla (-1)", 1, -1, 1)),
+    (11, 11, WeatherType("Lätt snö (-1)", 2, -1, 2)),
+    (12, 12, WeatherType("Klart (-2)", 4, -2, 3)),
+    (13, float("inf"), WeatherType("Torr och solig (-3)", 8, -3, 4)),
+]
+
+WEATHER_TABLES = {
+    "spring": SPRING_WEATHER_TABLE,
+    "summer": SUMMER_WEATHER_TABLE,
+    "autumn": AUTUMN_WEATHER_TABLE,
+    "winter": WINTER_WEATHER_TABLE,
+}
+
+NORMAL_WEATHER = {
+    "spring": "Normal vår (±0)",
+    "summer": "Normal sommar (±0)",
+    "autumn": "Normal höst (±0)",
+    "winter": "Normal vinter (±0)",
+}
+
+
+def get_weather_options(season: str) -> list[str]:
+    """Return a list of weather names for the given ``season``."""
+    return [wtype.name for _, _, wtype in WEATHER_TABLES[season]]
+
+
+def determine_weather_type(total: int, season: str) -> WeatherType:
+    """Return the WeatherType for ``total`` and ``season``."""
+    table = WEATHER_TABLES.get(season, SPRING_WEATHER_TABLE)
+    for low, high, wtype in table:
         if low <= total <= high:
             return wtype
     # Fallback, should never happen
-    return WeatherType("Normalväder", 0, 0, 0)
+    return WeatherType(NORMAL_WEATHER.get(season, "Normal vår (±0)"), 0, 0, 0)
 
 
-def roll_weather(modifier: int = 0) -> tuple[int, WeatherType]:
-    """Roll 2d6, apply ``modifier`` and return the resulting WeatherType."""
+def roll_weather(season: str, modifier: int = 0) -> tuple[int, WeatherType]:
+    """Roll 2d6 for ``season``, apply ``modifier`` and return the WeatherType."""
     roll = random.randint(1, 6) + random.randint(1, 6)
     total = roll + modifier
-    wtype = determine_weather_type(total)
+    wtype = determine_weather_type(total, season)
     return total, wtype

--- a/src/world_interface.py
+++ b/src/world_interface.py
@@ -11,6 +11,7 @@ from constants import (
     NEIGHBOR_OTHER_STR,
     DAGSVERKEN_LEVELS,
 )
+from weather import NORMAL_WEATHER
 
 
 class WorldInterface(ABC):
@@ -271,10 +272,10 @@ class WorldInterface(ABC):
                         updated = True
                 elif res_type == "Väder":
                     defaults = {
-                        "spring_weather": "Normalväder",
-                        "summer_weather": "Normalväder",
-                        "autumn_weather": "Normalväder",
-                        "winter_weather": "Normalväder",
+                        "spring_weather": NORMAL_WEATHER["spring"],
+                        "summer_weather": NORMAL_WEATHER["summer"],
+                        "autumn_weather": NORMAL_WEATHER["autumn"],
+                        "winter_weather": NORMAL_WEATHER["winter"],
                         "weather_effect": "",
                     }
                     for key, val in defaults.items():

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -397,7 +397,7 @@ def test_weather_node_clears_custom_name():
         "parent_id": 1,
         "res_type": "Väder",
         "custom_name": "Storm",
-        "spring_weather": "Solsken",
+        "spring_weather": "Varmt och stabilt (-1)",
     }
 
     node = Node.from_dict(raw)
@@ -405,4 +405,4 @@ def test_weather_node_clears_custom_name():
 
     back = node.to_dict()
     assert "custom_name" not in back
-    assert back["spring_weather"] == "Solsken"
+    assert back["spring_weather"] == "Varmt och stabilt (-1)"

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -14,16 +14,16 @@ def test_available_resource_types_excludes_weather():
 
 def test_roll_weather_table():
     with patch("random.randint", side_effect=[1, 1]):
-        total, w = roll_weather(modifier=-2)
+        total, w = roll_weather("spring", modifier=-2)
     assert total == 0
-    assert w.name == "Ödeläggelse"
+    assert w.name == "Storm och hagel (+3)"
 
     with patch("random.randint", side_effect=[6, 6]):
-        total, w = roll_weather()
+        total, w = roll_weather("spring")
     assert total == 12
-    assert w.name == "Fruktbarhet"
+    assert w.name == "God växtkraft (-2)"
 
     with patch("random.randint", side_effect=[6, 6]):
-        total, w = roll_weather(modifier=2)
+        total, w = roll_weather("spring", modifier=2)
     assert total == 14
-    assert w.name == "Mirakelväder"
+    assert w.name == "Exceptionellt vårväder (-3)"


### PR DESCRIPTION
## Summary
- define separate weather tables for spring, summer, autumn, and winter with hardship modifiers in names
- show dice roll totals when randomizing seasonal weather
- update node defaults and tests for new weather names

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68952e727548832e8c9a0483299a035a