### PR TITLE
Add dagsverken display and umbärande modifier

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -119,6 +119,18 @@ DAGSVERKEN_MULTIPLIERS = {
     "tyranniskt många": 120,
 }
 
+# Umbärande modifiers for each dagsverken level
+DAGSVERKEN_UMBARANDE = {
+    "inga": -2,
+    "få": -1,
+    "normalt": 0,
+    "många": 1,
+    "tyranniskt många": 2,
+}
+
+# Work days produced by a single thrall
+THRALL_WORK_DAYS = 300
+
 # Fish quality levels for sea and river resources
 FISH_QUALITY_LEVELS = [
     "Kassat",


### PR DESCRIPTION
## Summary
- Compute total dagsverken from thralls and unfree peasants
- Show dagsverken total and umbäranden modifier fields in settlement editor
- Define constants for thrall work and umbärande modifiers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895cdc7bab4832ebbd1628b6e5a2c4d