### PR TITLE
Show summed umbäranden for jarldoms

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -1723,6 +1723,14 @@ class FeodalSimulator:
             "write",
             lambda *_: self._auto_save_field(node_data, "work_needed", work_need_var.get().strip(), False),
         )
+        total_umbarande = self.world_manager.calculate_umbarande(node_id)
+        self._auto_save_field(node_data, "umbarande", total_umbarande, False)
+        row_idx += 1
+        ttk.Label(editor_frame, text="Summa umbäranden:").grid(row=row_idx, column=0, sticky="w", padx=5, pady=3)
+        umbarande_total_var = tk.StringVar(value=str(total_umbarande))
+        ttk.Entry(editor_frame, textvariable=umbarande_total_var, width=10, state="readonly").grid(
+            row=row_idx, column=1, sticky="w", padx=5, pady=3
+        )
 
         row_idx += 1
 

--- a/src/node.py
+++ b/src/node.py
@@ -36,6 +36,7 @@ class Node:
     dagsverken: str = "normalt"
     work_available: int = 0
     work_needed: int = 0
+    umbarande: int = 0
     storage_silver: int = 0
     storage_basic: int = 0
     storage_luxury: int = 0
@@ -237,6 +238,10 @@ class Node:
         except (ValueError, TypeError):
             work_needed = 0
         try:
+            umbarande = int(data.get("umbarande", 0) or 0)
+        except (ValueError, TypeError):
+            umbarande = 0
+        try:
             storage_silver = int(data.get("storage_silver", 0) or 0)
         except (ValueError, TypeError):
             storage_silver = 0
@@ -297,6 +302,7 @@ class Node:
             weather_effect=weather_effect,
             work_available=work_available,
             work_needed=work_needed,
+            umbarande=umbarande,
             storage_silver=storage_silver,
             storage_basic=storage_basic,
             storage_luxury=storage_luxury,
@@ -330,6 +336,7 @@ class Node:
             "cleared_land": self.cleared_land,
             "work_available": self.work_available,
             "work_needed": self.work_needed,
+            "umbarande": self.umbarande,
             "storage_silver": self.storage_silver,
             "storage_basic": self.storage_basic,
             "storage_luxury": self.storage_luxury,

--- a/src/world_manager.py
+++ b/src/world_manager.py
@@ -10,6 +10,7 @@ from constants import (
     NEIGHBOR_NONE_STR,
     BORDER_TYPES,
     DAGSVERKEN_MULTIPLIERS,
+    DAGSVERKEN_UMBARANDE,
     THRALL_WORK_DAYS,
 )
 from node import Node
@@ -195,6 +196,28 @@ class WorldManager(WorldInterface):
             except (ValueError, TypeError):
                 continue
             total += self.calculate_work_available(cid, visited)
+        return total
+
+    def calculate_umbarande(self, node_id: int, visited: set[int] | None = None) -> int:
+        """Sum umbäranden for ``node_id`` and all descendants."""
+
+        nodes = self.world_data.get("nodes", {})
+        if visited is None:
+            visited = set()
+        if node_id in visited:
+            return 0
+        visited.add(node_id)
+        node = nodes.get(str(node_id))
+        if not node:
+            return 0
+        level = node.get("dagsverken", "normalt")
+        total = DAGSVERKEN_UMBARANDE.get(level, 0)
+        for child in node.get("children", []):
+            try:
+                cid = int(child)
+            except (ValueError, TypeError):
+                continue
+            total += self.calculate_umbarande(cid, visited)
         return total
 
     def calculate_total_resources(

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -41,6 +41,7 @@ def test_node_from_dict_normalizes_fields():
     assert node.storage_basic == 0
     assert node.storage_luxury == 0
     assert node.jarldom_area == 0
+    assert node.umbarande == 0
 
 
 def test_node_settlement_roundtrip():
@@ -101,6 +102,7 @@ def test_node_jarldom_extra_fields_roundtrip():
         "parent_id": 1,
         "work_available": 5,
         "work_needed": 7,
+        "umbarande": 4,
         "storage_silver": 10,
         "storage_basic": 3,
         "storage_luxury": 1,
@@ -110,6 +112,7 @@ def test_node_jarldom_extra_fields_roundtrip():
     node = Node.from_dict(raw)
     assert node.work_available == 5
     assert node.work_needed == 7
+    assert node.umbarande == 4
     assert node.storage_silver == 10
     assert node.storage_basic == 3
     assert node.storage_luxury == 1
@@ -118,6 +121,7 @@ def test_node_jarldom_extra_fields_roundtrip():
     back = node.to_dict()
     assert back["work_available"] == 5
     assert back["work_needed"] == 7
+    assert back["umbarande"] == 4
     assert back["storage_silver"] == 10
     assert back["storage_basic"] == 3
     assert back["storage_luxury"] == 1

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -1,5 +1,11 @@
 from src.world_manager import WorldManager
-from src.constants import MAX_NEIGHBORS, NEIGHBOR_NONE_STR, DAGSVERKEN_MULTIPLIERS, THRALL_WORK_DAYS
+from src.constants import (
+    MAX_NEIGHBORS,
+    NEIGHBOR_NONE_STR,
+    DAGSVERKEN_MULTIPLIERS,
+    THRALL_WORK_DAYS,
+    DAGSVERKEN_UMBARANDE,
+)
 
 
 def test_attempt_link_neighbors_directional():
@@ -393,5 +399,53 @@ def test_calculate_work_available_excludes_other_jarldoms():
         + DAGSVERKEN_MULTIPLIERS["många"] * 2
         + THRALL_WORK_DAYS
         + DAGSVERKEN_MULTIPLIERS["inga"]
+    )
+    assert total == expected
+
+
+def test_calculate_umbarande_excludes_other_jarldoms():
+    world = {
+        "nodes": {
+            "1": {
+                "node_id": 1,
+                "parent_id": None,
+                "children": [2, 3],
+                "dagsverken": "normalt",
+            },
+            "2": {
+                "node_id": 2,
+                "parent_id": 1,
+                "children": [4],
+                "dagsverken": "många",
+            },
+            "3": {
+                "node_id": 3,
+                "parent_id": 1,
+                "children": [],
+                "dagsverken": "få",
+            },
+            "4": {
+                "node_id": 4,
+                "parent_id": 2,
+                "children": [],
+                "dagsverken": "inga",
+            },
+            "5": {
+                "node_id": 5,
+                "parent_id": None,
+                "children": [],
+                "dagsverken": "tyranniskt många",
+            },
+        },
+        "characters": {},
+    }
+
+    manager = WorldManager(world)
+    total = manager.calculate_umbarande(1)
+    expected = (
+        DAGSVERKEN_UMBARANDE["normalt"]
+        + DAGSVERKEN_UMBARANDE["många"]
+        + DAGSVERKEN_UMBARANDE["få"]
+        + DAGSVERKEN_UMBARANDE["inga"]
     )
     assert total == expected


### PR DESCRIPTION
## Summary
- add recursive world manager method to total umbäranden across a node hierarchy
- expose Summa umbäranden on jarldöme editor and persist value on nodes
- cover Node and world manager changes with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895dd0c34c0832eaeec63c4ee90c334