### PR TITLE
Include weather effect in umbärande totals

### DIFF
--- a/src/world_manager.py
+++ b/src/world_manager.py
@@ -199,7 +199,10 @@ class WorldManager(WorldInterface):
         return total
 
     def calculate_umbarande(self, node_id: int, visited: set[int] | None = None) -> int:
-        """Sum umbäranden for ``node_id`` and all descendants."""
+        """Sum umbäranden for ``node_id`` and all descendants.
+
+        Includes both dagsverken and weather modifiers stored on the node.
+        """
 
         nodes = self.world_data.get("nodes", {})
         if visited is None:
@@ -212,6 +215,10 @@ class WorldManager(WorldInterface):
             return 0
         level = node.get("dagsverken", "normalt")
         total = DAGSVERKEN_UMBARANDE.get(level, 0)
+        try:
+            total += int(node.get("weather_effect", 0) or 0)
+        except (ValueError, TypeError):
+            pass
         for child in node.get("children", []):
             try:
                 cid = int(child)

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -449,3 +449,29 @@ def test_calculate_umbarande_excludes_other_jarldoms():
         + DAGSVERKEN_UMBARANDE["inga"]
     )
     assert total == expected
+
+
+def test_calculate_umbarande_includes_weather_effect():
+    world = {
+        "nodes": {
+            "1": {
+                "node_id": 1,
+                "parent_id": None,
+                "children": [2],
+                "dagsverken": "normalt",
+            },
+            "2": {
+                "node_id": 2,
+                "parent_id": 1,
+                "children": [],
+                "res_type": "Väder",
+                "weather_effect": 5,
+            },
+        },
+        "characters": {},
+    }
+
+    manager = WorldManager(world)
+    total = manager.calculate_umbarande(1)
+    expected = DAGSVERKEN_UMBARANDE["normalt"] + 5
+    assert total == expected


### PR DESCRIPTION
## Summary
- add weather effect field to umbärande summation in `WorldManager`
- test that weather nodes contribute to total umbäranden

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895e5da99e4832e9ed57e2f724ff4ef