### PR TITLE
Add river level option for river resources

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -2215,6 +2215,23 @@ class FeodalSimulator:
         boats_combo.grid(row=row_idx, column=1, sticky="w", padx=5, pady=3)
         row_idx += 1
 
+        river_label = ttk.Label(editor_frame, text="Flodnivå:")
+        river_var = tk.StringVar(value=str(node_data.get("river_level", 1)))
+        river_combo = ttk.Combobox(
+            editor_frame,
+            textvariable=river_var,
+            values=[str(i) for i in range(1, 11)],
+            state="readonly",
+            width=5,
+        )
+        river_var.trace_add(
+            "write",
+            lambda *_: self._auto_save_field(node_data, "river_level", river_var.get().strip(), False),
+        )
+        river_label.grid(row=row_idx, column=0, sticky="w", padx=5, pady=3)
+        river_combo.grid(row=row_idx, column=1, sticky="w", padx=5, pady=3)
+        row_idx += 1
+
         gamekeeper_label = ttk.Label(editor_frame, text="Jägarmästare:")
         gamekeeper_var = tk.StringVar()
         gk_options = ["Ingen karaktär"]
@@ -2282,11 +2299,19 @@ class FeodalSimulator:
                 fish_combo.grid()
                 boats_label.grid()
                 boats_combo.grid()
+                if res_var.get() == "Flod":
+                    river_label.grid()
+                    river_combo.grid()
+                else:
+                    river_label.grid_remove()
+                    river_combo.grid_remove()
             else:
                 water_label.grid_remove()
                 fish_combo.grid_remove()
                 boats_label.grid_remove()
                 boats_combo.grid_remove()
+                river_label.grid_remove()
+                river_combo.grid_remove()
 
         def refresh_hunt_visibility(*_):
             if res_var.get() == "Jaktmark":
@@ -3104,9 +3129,17 @@ class FeodalSimulator:
                     node_data["fishing_boats"] = int(boats_var.get() or "0", 10)
                 except (tk.TclError, ValueError):
                     node_data["fishing_boats"] = 0
+                if res_var.get() == "Flod":
+                    try:
+                        node_data["river_level"] = int(river_var.get() or "1", 10)
+                    except (tk.TclError, ValueError):
+                        node_data["river_level"] = 1
+                else:
+                    node_data.pop("river_level", None)
             else:
                 node_data.pop("fish_quality", None)
                 node_data.pop("fishing_boats", None)
+                node_data.pop("river_level", None)
             temp_data = dict(node_data)
             if res_var.get() in {"Vildmark", "Jaktmark"}:
                 try:

--- a/src/node.py
+++ b/src/node.py
@@ -72,6 +72,7 @@ class Node:
     buildings: List[dict] = field(default_factory=list)
     fish_quality: str = "Normalt"
     fishing_boats: int = 0
+    river_level: int = 1
     hunters: int = 0
     gamekeeper_id: Optional[int] = None
     spring_weather: str = NORMAL_WEATHER["spring"]
@@ -213,6 +214,7 @@ class Node:
 
         fish_quality = "Normalt"
         fishing_boats = 0
+        river_level = 1
         hunters = 0
         gamekeeper_id = data.get("gamekeeper_id")
         if isinstance(gamekeeper_id, str) and gamekeeper_id.isdigit():
@@ -234,6 +236,12 @@ class Node:
             except (ValueError, TypeError):
                 fishing_boats = 0
             fishing_boats = max(0, min(fishing_boats, MAX_FISHING_BOATS))
+        if res_type == "Flod":
+            try:
+                river_level = int(data.get("river_level", 1) or 1)
+            except (ValueError, TypeError):
+                river_level = 1
+            river_level = max(1, min(river_level, 10))
         if res_type == "Jaktmark":
             try:
                 hunters = int(data.get("hunters", 0) or 0)
@@ -331,6 +339,7 @@ class Node:
             buildings=buildings,
             fish_quality=fish_quality,
             fishing_boats=fishing_boats,
+            river_level=river_level,
             hunters=hunters,
             gamekeeper_id=gamekeeper_id,
             spring_weather=spring_weather,
@@ -424,6 +433,8 @@ class Node:
         if self.res_type in {"Hav", "Flod"}:
             data["fish_quality"] = self.fish_quality
             data["fishing_boats"] = self.fishing_boats
+            if self.res_type == "Flod":
+                data["river_level"] = self.river_level
 
         if self.res_type == "Jaktmark":
             data["hunters"] = self.hunters
@@ -463,6 +474,7 @@ class Node:
                 "buildings",
                 "fish_quality",
                 "fishing_boats",
+                "river_level",
                 "hunters",
                 "gamekeeper_id",
                 "manor_land",

--- a/src/world_interface.py
+++ b/src/world_interface.py
@@ -260,6 +260,20 @@ class WorldInterface(ABC):
                     if "population" in node:
                         del node["population"]
                         updated = True
+                elif res_type in {"Hav", "Flod"}:
+                    if "fish_quality" not in node:
+                        node["fish_quality"] = "Normalt"
+                        updated = True
+                    if "fishing_boats" not in node:
+                        node["fishing_boats"] = 0
+                        updated = True
+                    if res_type == "Flod":
+                        if "river_level" not in node:
+                            node["river_level"] = 1
+                            updated = True
+                    elif "river_level" in node:
+                        del node["river_level"]
+                        updated = True
                 elif res_type == "Lager":
                     defaults = {
                         "lager_text": "",
@@ -296,6 +310,7 @@ class WorldInterface(ABC):
                         "hunting_law",
                         "fish_quality",
                         "fishing_boats",
+                        "river_level",
                     ):
                         if key in node:
                             del node[key]
@@ -341,6 +356,7 @@ class WorldInterface(ABC):
                         "hunting_law",
                         "fish_quality",
                         "fishing_boats",
+                        "river_level",
                     ):
                         if key in node:
                             del node[key]

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -419,6 +419,36 @@ def test_node_water_fields_ignored_for_other_types():
     assert "fishing_boats" not in back
 
 
+def test_node_river_level_roundtrip():
+    raw = {
+        "node_id": 72,
+        "parent_id": 1,
+        "res_type": "Flod",
+        "river_level": 3,
+    }
+
+    node = Node.from_dict(raw)
+    assert node.river_level == 3
+
+    back = node.to_dict()
+    assert back["river_level"] == 3
+
+
+def test_node_river_level_ignored_for_other_types():
+    raw = {
+        "node_id": 73,
+        "parent_id": 1,
+        "res_type": "Hav",
+        "river_level": 5,
+    }
+
+    node = Node.from_dict(raw)
+    assert node.river_level == 1
+
+    back = node.to_dict()
+    assert "river_level" not in back
+
+
 def test_node_characters_roundtrip():
     raw = {
         "node_id": 50,

--- a/tests/test_world_interface.py
+++ b/tests/test_world_interface.py
@@ -200,6 +200,26 @@ def test_validate_world_data_lager_defaults():
     assert "tunnland" not in node
 
 
+def test_validate_world_data_water_defaults():
+    world = {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None, "res_type": "Flod"},
+            "2": {"node_id": 2, "parent_id": None, "res_type": "Hav", "river_level": 5},
+        },
+        "characters": {},
+    }
+    manager = WorldManager(world)
+    manager.get_depth_of_node = lambda _nid: 5
+    nodes_updated, _ = manager.validate_world_data()
+    assert nodes_updated > 0
+    n1 = world["nodes"]["1"]
+    n2 = world["nodes"]["2"]
+    assert n1["fish_quality"] == "Normalt"
+    assert n1["fishing_boats"] == 0
+    assert n1["river_level"] == 1
+    assert "river_level" not in n2
+
+
 def test_update_neighbors_for_node_bidirectional():
     world = {
         "nodes": {


### PR DESCRIPTION
## Summary
- add `river_level` field to nodes and support 1-10 river levels
- show river level dropdown when the Flod resource type is selected
- normalize river data in world validation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689694aa44a4832eab7836d25b11d36e