### PR TITLE
Add license income field for jarldoms

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -1807,6 +1807,12 @@ class FeodalSimulator:
         day_hired_entry = ttk.Entry(editor_frame, textvariable=day_hired_var, width=5)
         day_hired_entry.grid(row=row_idx, column=3, sticky="w", padx=5, pady=3)
 
+        row_idx += 1
+        ttk.Label(editor_frame, text="Förväntad licens:").grid(row=row_idx, column=2, sticky="w", padx=5, pady=3)
+        license_var = tk.StringVar(value=str(node_data.get("expected_license_income", 0)))
+        license_entry = ttk.Entry(editor_frame, textvariable=license_var, width=5)
+        license_entry.grid(row=row_idx, column=3, sticky="w", padx=5, pady=3)
+
         def update_day_laborers(*_args) -> None:
             try:
                 avail = int(day_avail_var.get() or "0")
@@ -1828,6 +1834,12 @@ class FeodalSimulator:
 
         day_avail_var.trace_add("write", update_day_laborers)
         day_hired_var.trace_add("write", update_day_laborers)
+        license_var.trace_add(
+            "write",
+            lambda *_: self._auto_save_field(
+                node_data, "expected_license_income", license_var.get().strip(), False
+            ),
+        )
         update_day_laborers()
 
         # expose for tests

--- a/src/node.py
+++ b/src/node.py
@@ -48,6 +48,7 @@ class Node:
     storage_animal_feed: int = 0
     storage_skin: int = 0
     jarldom_area: int = 0
+    expected_license_income: int = 0
     free_peasants: int = 0
     unfree_peasants: int = 0
     thralls: int = 0
@@ -301,6 +302,10 @@ class Node:
             jarldom_area = int(data.get("jarldom_area", 0) or 0)
         except (ValueError, TypeError):
             jarldom_area = 0
+        try:
+            expected_license_income = int(data.get("expected_license_income", 0) or 0)
+        except (ValueError, TypeError):
+            expected_license_income = 0
 
         return cls(
             node_id=node_id,
@@ -361,6 +366,7 @@ class Node:
             storage_animal_feed=storage_animal_feed,
             storage_skin=storage_skin,
             jarldom_area=jarldom_area,
+            expected_license_income=expected_license_income,
         )
 
     def to_dict(self) -> dict:
@@ -404,6 +410,7 @@ class Node:
             "storage_animal_feed": self.storage_animal_feed,
             "storage_skin": self.storage_skin,
             "jarldom_area": self.jarldom_area,
+            "expected_license_income": self.expected_license_income,
             "craftsmen": [
                 {"type": c.get("type", ""), "count": c.get("count", 1)}
                 for c in self.craftsmen
@@ -469,6 +476,7 @@ class Node:
                 "storage_animal_feed",
                 "storage_skin",
                 "jarldom_area",
+                "expected_license_income",
                 "craftsmen",
                 "characters",
                 "buildings",

--- a/src/world_interface.py
+++ b/src/world_interface.py
@@ -182,6 +182,7 @@ class WorldInterface(ABC):
                     "storage_basic",
                     "storage_luxury",
                     "jarldom_area",
+                    "expected_license_income",
                 ):
                     if key not in node:
                         node[key] = 0

--- a/src/world_manager.py
+++ b/src/world_manager.py
@@ -236,6 +236,30 @@ class WorldManager(WorldInterface):
             total += self.calculate_umbarande(cid, visited)
         return total
 
+    def calculate_license_income(self, node_id: int, visited: set[int] | None = None) -> int:
+        """Sum expected license income for ``node_id`` and all descendants."""
+
+        nodes = self.world_data.get("nodes", {})
+        if visited is None:
+            visited = set()
+        if node_id in visited:
+            return 0
+        visited.add(node_id)
+        node = nodes.get(str(node_id))
+        if not node:
+            return 0
+        try:
+            total = int(node.get("expected_license_income", 0) or 0)
+        except (ValueError, TypeError):
+            total = 0
+        for child in node.get("children", []):
+            try:
+                cid = int(child)
+            except (ValueError, TypeError):
+                continue
+            total += self.calculate_license_income(cid, visited)
+        return total
+
     def calculate_total_resources(
         self,
         node_id: int,

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -48,6 +48,7 @@ def test_node_from_dict_normalizes_fields():
     assert node.storage_animal_feed == 0
     assert node.storage_skin == 0
     assert node.jarldom_area == 0
+    assert node.expected_license_income == 0
     assert node.umbarande == 0
 
 
@@ -114,6 +115,7 @@ def test_node_jarldom_extra_fields_roundtrip():
         "storage_basic": 3,
         "storage_luxury": 1,
         "jarldom_area": 50,
+        "expected_license_income": 12,
     }
 
     node = Node.from_dict(raw)
@@ -124,6 +126,7 @@ def test_node_jarldom_extra_fields_roundtrip():
     assert node.storage_basic == 3
     assert node.storage_luxury == 1
     assert node.jarldom_area == 50
+    assert node.expected_license_income == 12
 
     back = node.to_dict()
     assert back["work_available"] == 5
@@ -133,6 +136,7 @@ def test_node_jarldom_extra_fields_roundtrip():
     assert back["storage_basic"] == 3
     assert back["storage_luxury"] == 1
     assert back["jarldom_area"] == 50
+    assert back["expected_license_income"] == 12
 
 
 def test_node_lager_roundtrip():

--- a/tests/test_world_interface.py
+++ b/tests/test_world_interface.py
@@ -92,6 +92,7 @@ def test_validate_world_data_basic():
         "storage_basic",
         "storage_luxury",
         "jarldom_area",
+        "expected_license_income",
     ):
         assert key in node2 and node2[key] == 0
 

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -494,3 +494,45 @@ def test_calculate_umbarande_includes_weather_effect():
     total = manager.calculate_umbarande(1)
     expected = DAGSVERKEN_UMBARANDE["normalt"] + 5
     assert total == expected
+
+
+def test_calculate_license_income_sums_descendants():
+    world = {
+        "nodes": {
+            "1": {
+                "node_id": 1,
+                "parent_id": None,
+                "children": [2, 3],
+                "expected_license_income": 1,
+            },
+            "2": {
+                "node_id": 2,
+                "parent_id": 1,
+                "children": [4],
+                "expected_license_income": 2,
+            },
+            "3": {
+                "node_id": 3,
+                "parent_id": 1,
+                "children": [],
+                "expected_license_income": 3,
+            },
+            "4": {
+                "node_id": 4,
+                "parent_id": 2,
+                "children": [],
+                "expected_license_income": 4,
+            },
+            "5": {
+                "node_id": 5,
+                "parent_id": None,
+                "children": [],
+                "expected_license_income": 100,
+            },
+        },
+        "characters": {},
+    }
+
+    manager = WorldManager(world)
+    total = manager.calculate_license_income(1)
+    assert total == 1 + 2 + 3 + 4


### PR DESCRIPTION
## Summary
- add expected license income field to jarldoms and expose it in the editor
- support license income in Node schema and world validation
- implement and test recursive license income calculation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68969f612f78832e9cb542189938fbff