### PR TITLE
Add settlement craftsman license calculations

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -63,18 +63,26 @@ ANIMAL_TYPES = {"Stridshästar", "Ridhästar", "Packhästar", "Draghästar", "Ox
 MISC_COUNT_TYPES = {"Jägare", "Båtar"}
 BUILDING_TYPES = {"Kvarn - vatten", "Kvarn - vind", "Bageri", "Smedja", "Garveri"}
 
-# Example list of possible craftsman professions for settlement UI
-CRAFTSMAN_TYPES = [
-    "Smed",
-    "Snickare",
-    "Bagare",
-    "Skräddare",
-    "Bryggare",
-    "Skomakare",
-    "Korgmakare",
-    "Timmerman",
-    "Målare",
-]
+# License fees for craftsmen in settlements
+CRAFTSMAN_LICENSE_FEES = {
+    "Båtbyggare": 200,
+    "Garvare": 100,
+    "Mjölnare": 100,
+    "Körsnär": 200,
+    "Skräddare": 150,
+    "Smed": 150,
+    "Snickare": 150,
+    "Värdshusvärd": 200,
+    "Bagare": 100,
+    "Bryggare": 125,
+    "Skomakare": 100,
+    "Timmerman": 150,
+    "Korgmakare": 50,
+    "Tunnbindare": 125,
+}
+
+# Available craftsman professions for settlement UI
+CRAFTSMAN_TYPES = list(CRAFTSMAN_LICENSE_FEES.keys())
 
 # Border types for neighbors
 BORDER_TYPES = [

--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -1618,6 +1618,9 @@ class FeodalSimulator:
 
         node_data["neighbors"] = validated_neighbors
 
+        # Update license income from any craftsmen under this jarldom
+        license_total = self.world_manager.update_license_income(node_id)
+        node_data["expected_license_income"] = license_total
 
         # Main content frame for this editor
         editor_frame = ttk.Frame(parent_frame)

--- a/tests/test_license_calculation.py
+++ b/tests/test_license_calculation.py
@@ -1,0 +1,27 @@
+from world_manager import WorldManager
+from constants import CRAFTSMAN_LICENSE_FEES
+
+def test_update_license_income_from_craftsmen():
+    world = {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None, "children": [2]},
+            "2": {
+                "node_id": 2,
+                "parent_id": 1,
+                "children": [],
+                "craftsmen": [
+                    {"type": "Smed", "count": 2},
+                    {"type": "Bagare", "count": 1},
+                ],
+            },
+        },
+        "characters": {},
+    }
+    manager = WorldManager(world)
+    total = manager.update_license_income(1)
+    expected = (
+        CRAFTSMAN_LICENSE_FEES["Smed"] * 2
+        + CRAFTSMAN_LICENSE_FEES["Bagare"] * 1
+    )
+    assert total == expected
+    assert world["nodes"]["1"]["expected_license_income"] == expected


### PR DESCRIPTION
## Summary
- define license fees for settlement craftsmen and expose new professions
- calculate jarldom license income from craftsmen and display in editor
- add tests for craftsman license income

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896ab91ef1c832eab2ffa3a9b663151