### PR TITLE
Add coverage reporting to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
@@ -22,7 +22,7 @@ jobs:
         run: |
           PYTHONPATH=src pytest --cov=src
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage-report
+          name: coverage-report-${{ matrix.runs-on }}
           path: coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install pytest
+          pip install -r requirements.txt
       - name: Run tests
         run: |
-          PYTHONPATH=src pytest
+          PYTHONPATH=src pytest --cov=src
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: coverage.xml

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --cov-report=xml --cov-report=term-missing
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-cov


### PR DESCRIPTION
## Summary
- add pytest and pytest-cov to project requirements
- configure pytest to produce coverage reports
- run tests with coverage in CI and upload report artifact

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pytest-cov)*
- `PYTHONPATH=src pytest --cov=src` *(fails: error: unrecognized arguments: --cov-report=xml --cov-report=term-missing --cov=src)*

------
https://chatgpt.com/codex/tasks/task_e_689850b3001483228ccc2266ee905bbe