### PR TITLE
Add tests for dual map tool and dynamic map

### DIFF
--- a/tests/test_dual_map_tool.py
+++ b/tests/test_dual_map_tool.py
@@ -1,0 +1,34 @@
+from dual_map_tool import World, History
+
+
+def test_add_node_and_save_load(tmp_path):
+    world = World()
+    n1 = world.add_node("A", None, 0, 0)
+    n2 = world.add_node("B", n1.node_id, 0, 1)
+
+    assert n2.node_id in world.nodes[n1.node_id].neighbors
+    assert n1.node_id in world.nodes[n2.node_id].neighbors
+
+    save_file = tmp_path / "world.json"
+    world.save(save_file)
+
+    new_world = World()
+    new_world.load(save_file)
+    assert len(new_world.nodes) == 2
+    assert new_world.nodes[n2.node_id].neighbors == [n1.node_id]
+
+
+def test_history_undo_redo():
+    world = World()
+    history = History(world)
+    world.add_node("A", None, 0, 0)
+    history.push()
+    world.add_node("B", 1, 0, 1)
+
+    assert 2 in world.nodes
+
+    history.undo()
+    assert 2 not in world.nodes
+
+    history.redo()
+    assert 2 in world.nodes

--- a/tests/test_dynamic_map.py
+++ b/tests/test_dynamic_map.py
@@ -1,0 +1,47 @@
+import pytest
+
+from dynamic_map import DynamicMapCanvas
+
+
+class DummyCanvas:
+    def __init__(self):
+        self.width = 500
+        self.height = 300
+        self.scale_calls = []
+
+    def winfo_width(self):
+        return self.width
+
+    def winfo_height(self):
+        return self.height
+
+    def canvasx(self, x):
+        return x
+
+    def canvasy(self, y):
+        return y
+
+    def scale(self, tag, x, y, sx, sy):
+        self.scale_calls.append((tag, x, y, sx, sy))
+
+
+def test_set_world_data():
+    canvas = DynamicMapCanvas(None, None, {"nodes": {}})
+    new_data = {"nodes": {"1": {"node_id": 1}}}
+    canvas.set_world_data(new_data)
+    assert canvas.world_data is new_data
+
+
+def test_on_dynamic_map_zoom():
+    canvas = DynamicMapCanvas(None, None, None)
+    canvas.canvas = DummyCanvas()
+
+    event = type("Evt", (), {"delta": 120, "num": 0})()
+    canvas.on_dynamic_map_zoom(event)
+    assert canvas.dynamic_scale == pytest.approx(1.1)
+    assert canvas.canvas.scale_calls[0] == ("all", 250.0, 150.0, 1.1, 1.1)
+
+    canvas.dynamic_scale = 0.11
+    event_neg = type("Evt", (), {"delta": -120, "num": 0})()
+    canvas.on_dynamic_map_zoom(event_neg)
+    assert canvas.dynamic_scale == pytest.approx(0.1)


### PR DESCRIPTION
## Summary
- add tests for World and History in dual_map_tool
- add tests for DynamicMapCanvas zoom behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898530b57648322a47dd3e827fca4fc