### PR TITLE
Enforce minimum test coverage in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           pip install -r requirements.txt
       - name: Run tests
         run: |
-          PYTHONPATH=src pytest --cov=src
+          PYTHONPATH=src pytest --cov=src --cov-fail-under=45
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- enforce a 45% coverage threshold in the test workflow using `--cov-fail-under`

## Testing
- `PYTHONPATH=src pytest --cov=src --cov-fail-under=45`

------
https://chatgpt.com/codex/tasks/task_e_689856096e508322819a6db94d35bbb4