### PR TITLE
Add tests for name generation and slot display scripts

### DIFF
--- a/tests/test_generate_names.py
+++ b/tests/test_generate_names.py
@@ -1,0 +1,16 @@
+import random
+from generate_names import main
+from name_randomizer import NameRandomizer
+
+
+def test_main_prints_deterministic_names(capsys):
+    random.seed(0)
+    rand = NameRandomizer()
+    expected = [rand.random_name() for _ in range(50)]
+
+    random.seed(0)
+    main()
+    captured = capsys.readouterr()
+    output = captured.out.strip().splitlines()
+    assert output == expected
+    assert len(output) == 50

--- a/tests/test_show_slots.py
+++ b/tests/test_show_slots.py
@@ -1,0 +1,9 @@
+from show_slots import main
+from slot_display import CharacterSlotDisplay
+
+
+def test_main_outputs_expected_display(capsys):
+    expected = CharacterSlotDisplay().to_text() + "\n"
+    main()
+    captured = capsys.readouterr()
+    assert captured.out == expected


### PR DESCRIPTION
## Summary
- add regression test for generate_names script, ensuring deterministic output and line count
- verify show_slots script prints the expected character slot display

## Testing
- `pytest tests/test_generate_names.py tests/test_show_slots.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689856e5fff48322856cb09394015c48