### PR TITLE
docs: clarify pytest usage in AGENTS notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,4 +10,5 @@ Notes
 -----
 
 - Always add tests when possible.
+- Run the test suite from the repository root with `pytest` (e.g., `pytest --cov`).
 


### PR DESCRIPTION
## Summary
- note that contributors should run the test suite with `pytest` from the repository root

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68985994853c8322bc25305c27966443