### PR TITLE
Add Codecov coverage reporting and badge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,12 @@ jobs:
           pip install -r requirements.txt
       - name: Run tests
         run: |
-          PYTHONPATH=src pytest --cov=src --cov-fail-under=45
+          PYTHONPATH=src pytest --cov=src --cov-report=xml --cov-fail-under=45
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
+          fail_ci_if_error: true
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,12 +22,13 @@ jobs:
         run: |
           PYTHONPATH=src pytest --cov=src --cov-report=xml --cov-fail-under=45
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report-${{ matrix.runs-on }}
+          name: coverage-report
           path: coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # feudal-simulator
+[![codecov](https://codecov.io/gh/OWNER/feudal-simulator/branch/main/graph/badge.svg)](https://codecov.io/gh/OWNER/feudal-simulator)
 
 This project is a small prototype for a feudal county simulation. The code
 is split across multiple modules under `src/`.


### PR DESCRIPTION
## Summary
- add Codecov upload step to CI workflow and generate XML coverage report
- show coverage badge in README (replace `OWNER` in the URL with your repository owner or organization)

## Testing
- `PYTHONPATH=src pytest --cov=src --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_68985aa617388322842f8fa4916ce081