### PR TITLE
docs: mention installing dependencies before tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,5 +19,6 @@ Notes
 -----
 
 - Always add tests when possible.
+- Install dependencies with `pip install -r requirements.txt` before running tests.
 - Run the test suite from the repository root with `pytest` (e.g., `pytest --cov`).
 


### PR DESCRIPTION
## Summary
- document installing dependencies with `pip install -r requirements.txt` before running tests

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68986002ad908322aa6e5664d476120f