### PR TITLE
Extract population calculation utility

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -38,6 +38,7 @@ from utils import (
 from dynamic_map import DynamicMapCanvas
 from map_logic import StaticMapLogic
 from world_manager import WorldManager
+from population_utils import calculate_population_from_fields
 from weather import roll_weather, get_weather_options, NORMAL_WEATHER
 
 # --------------------------------------------------
@@ -213,23 +214,6 @@ class FeodalSimulator:
             "Förläningssimulator\nEn enkel simulator av förläningar.",
         )
 
-    @staticmethod
-    def calculate_population_from_fields(data: dict) -> int:
-        """Compute total population from category fields."""
-        try:
-            free_p = int(data.get("free_peasants", 0) or 0)
-            unfree_p = int(data.get("unfree_peasants", 0) or 0)
-            thralls = int(data.get("thralls", 0) or 0)
-            burghers = int(data.get("burghers", 0) or 0)
-        except ValueError:
-            free_p = unfree_p = thralls = burghers = 0
-        total = free_p + unfree_p + thralls + burghers
-        if total:
-            return total
-        try:
-            return int(data.get("population", 0) or 0)
-        except ValueError:
-            return 0
 
     # --- Status Methods ---
     def add_status_message(self, msg):
@@ -3182,7 +3166,7 @@ class FeodalSimulator:
                 except (tk.TclError, ValueError):
                     manual_pop = 0
                 temp_data["population"] = manual_pop
-            node_data["population"] = self.calculate_population_from_fields(temp_data)
+            node_data["population"] = calculate_population_from_fields(temp_data)
             node_data["num_subfiefs"] = len(node_data.get("children", [])) + 1
             self.update_subfiefs_for_node(node_data)
             if res_var.get() == "Väder":
@@ -3329,7 +3313,7 @@ class FeodalSimulator:
             if res_var.get() in {"Vildmark", "Djur", "Väder"}:
                 new_pop = 0
             else:
-                new_pop = self.calculate_population_from_fields({
+                new_pop = calculate_population_from_fields({
                     "population": manual_pop,
                     "free_peasants": new_free,
                     "unfree_peasants": new_unfree,

--- a/src/population_utils.py
+++ b/src/population_utils.py
@@ -1,0 +1,39 @@
+"""Utility functions related to population calculations."""
+
+from __future__ import annotations
+
+
+def calculate_population_from_fields(data: dict) -> int:
+    """Compute total population from category fields.
+
+    The function sums specific population categories. If the total of
+    those categories is zero, it falls back to the ``population`` field.
+    All non-numeric values are treated as zero.
+
+    Parameters
+    ----------
+    data:
+        Mapping containing population information.
+
+    Returns
+    -------
+    int
+        The computed total population.
+    """
+
+    try:
+        free_p = int(data.get("free_peasants", 0) or 0)
+        unfree_p = int(data.get("unfree_peasants", 0) or 0)
+        thralls = int(data.get("thralls", 0) or 0)
+        burghers = int(data.get("burghers", 0) or 0)
+    except (ValueError, TypeError):
+        free_p = unfree_p = thralls = burghers = 0
+
+    total = free_p + unfree_p + thralls + burghers
+    if total:
+        return total
+
+    try:
+        return int(data.get("population", 0) or 0)
+    except (ValueError, TypeError):
+        return 0

--- a/tests/test_feodal_simulator.py
+++ b/tests/test_feodal_simulator.py
@@ -1,10 +1,12 @@
 import pytest
 
 from src import feodal_simulator as fs
+from src import population_utils as pu
 
 
 class DummyText:
     """Minimal stand-in for a tkinter Text widget."""
+
     def __init__(self):
         self.content = ""
         self.state = "disabled"
@@ -25,10 +27,15 @@ class DummyText:
 
 
 def test_calculate_population_from_fields():
-    data = {"free_peasants": "2", "unfree_peasants": "3", "thralls": "1", "burghers": "4"}
-    assert fs.FeodalSimulator.calculate_population_from_fields(data) == 10
-    assert fs.FeodalSimulator.calculate_population_from_fields({"population": "7"}) == 7
-    assert fs.FeodalSimulator.calculate_population_from_fields({"population": "bad"}) == 0
+    data = {
+        "free_peasants": "2",
+        "unfree_peasants": "3",
+        "thralls": "1",
+        "burghers": "4",
+    }
+    assert pu.calculate_population_from_fields(data) == 10
+    assert pu.calculate_population_from_fields({"population": "7"}) == 7
+    assert pu.calculate_population_from_fields({"population": "bad"}) == 0
 
 
 def test_add_status_message_appends_and_disables():

--- a/tests/test_population_utils.py
+++ b/tests/test_population_utils.py
@@ -1,0 +1,37 @@
+import pytest
+
+from src import population_utils as pu
+
+
+def test_missing_fields_return_zero():
+    assert pu.calculate_population_from_fields({}) == 0
+
+
+def test_invalid_values_use_population_fallback():
+    data = {
+        "free_peasants": "bad",
+        "unfree_peasants": "1",
+        "thralls": "bad",
+        "burghers": "bad",
+        "population": "5",
+    }
+    assert pu.calculate_population_from_fields(data) == 5
+
+
+def test_invalid_population_returns_zero():
+    assert pu.calculate_population_from_fields({"population": "bad"}) == 0
+
+
+def test_non_dict_input_raises():
+    with pytest.raises(AttributeError):
+        pu.calculate_population_from_fields(None)
+
+
+def test_negative_values_are_summed_when_nonzero():
+    data = {
+        "free_peasants": "-5",
+        "unfree_peasants": "3",
+        "thralls": "2",
+        "burghers": "1",
+    }
+    assert pu.calculate_population_from_fields(data) == 1


### PR DESCRIPTION
## Summary
- move `calculate_population_from_fields` into new `population_utils` module
- update simulator and tests to import the shared utility
- add comprehensive tests for population edge cases

## Testing
- `black src/population_utils.py tests/test_population_utils.py tests/test_feodal_simulator.py && black --check src/feodal_simulator.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899921de010832283e48b449466c26a