### PR TITLE
Auto-update jarldom work requirements

### DIFF
--- a/src/world_manager.py
+++ b/src/world_manager.py
@@ -253,6 +253,20 @@ class WorldManager(WorldInterface):
 
         return total
 
+    def update_work_needed(self, jarldom_id: int) -> int:
+        """Recalculate and store ``work_needed`` for a jarldom.
+
+        ``calculate_work_needed`` sums the requirement for the jarldom and
+        all descendant resource nodes.  This helper simply stores that sum on
+        the jarldom's node and returns the total for convenience.
+        """
+
+        total = self.calculate_work_needed(jarldom_id)
+        node = self.world_data.get("nodes", {}).get(str(jarldom_id))
+        if node is not None:
+            node["work_needed"] = total
+        return total
+
     def calculate_umbarande(self, node_id: int, visited: set[int] | None = None) -> int:
         """Sum umbäranden for ``node_id`` and all descendants.
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -563,3 +563,57 @@ def test_work_need_entry_color_updates():
     assert sim.work_need_entry.cget("foreground") == "black"
 
     root.destroy()
+
+
+def test_jarldom_work_need_updates_from_resource():
+    world = {
+        "nodes": {
+            "1": {
+                "node_id": 1,
+                "parent_id": None,
+                "children": [2],
+                "dagsverken": "normalt",
+                "day_laborers_available": 0,
+                "day_laborers_hired": 0,
+                "work_needed": 0,
+                "work_available": 0,
+            },
+            "2": {
+                "node_id": 2,
+                "parent_id": 1,
+                "children": [],
+                "res_type": "Åker",
+                "work_needed": 10,
+            },
+        },
+        "characters": {},
+    }
+
+    sim = DummySimulator()
+    sim.world_data = world
+    sim.world_manager = fs.WorldManager(world)
+    sim.get_depth_of_node = lambda nid: 3 if nid == 1 else 4
+    sim._update_umbarande_totals = lambda *a, **k: None
+    sim.show_neighbor_editor = lambda *a, **k: None
+    sim.save_current_world = lambda: None
+    sim.refresh_tree_item = lambda *a, **k: None
+    sim.add_status_message = lambda *a, **k: None
+
+    try:
+        root = tk.Tk()
+        root.withdraw()
+    except tk.TclError:
+        pytest.skip("Tk display not available")
+    frame = tk.Frame(root)
+    frame.pack()
+    sim._show_jarldome_editor(frame, world["nodes"]["1"])
+
+    assert sim.work_need_var.get() == "10"
+
+    child = world["nodes"]["2"]
+    sim._auto_save_field(child, "work_needed", 20, False)
+    root.update_idletasks()
+
+    assert sim.work_need_var.get() == "20"
+
+    root.destroy()


### PR DESCRIPTION
## Summary
- Recalculate and store jarldom work-needed totals in `WorldManager`
- Auto-update jarldom work need display when resource nodes change and make field read-only
- Test that jarldom work need reflects changes from resource nodes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b040fca7c832e9fdb6ddd0774c91c