### PR TITLE
Switch to yearly timeline controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ wheel and pan by dragging with the middle mouse button.
 
 ## Time engine
 
-The simulator keeps track of years and seasons (spring, summer, autumn, winter).
+The simulator now works with whole years only.
 
-- **Controls**: Six toolbar buttons (−10y, −1y, −Season, +Season, +1y, +10y) step the active timeline. The current time is shown next to the buttons and updates immediately.
-- **Deterministic RNG**: Use `rng_for(timeline_id, year, season, node_id, subsystem_tag, base_seed)` from `src/time_engine.py` to seed randomness. `roll_weather` accepts an explicit PRNG to keep weather rolls deterministic.
-- **Snapshots and event log**: Every season is stored in `src/save/saves/timelines/` as a compressed snapshot with an accompanying event list. Jumping backwards loads the closest stored snapshot, while jumping forwards auto-plays missing seasons.
-- **Integration points**: Weather now runs per season; orders/production/tax flows can plug in via custom `season_processors` without altering their internal rules.
-- **Testing**: New regression and determinism tests live in `tests/time/`. UI-coupled tests skip automatically when no Tk display is available.
+- **Controls**: Four toolbar buttons (−1 år, +1 år, Planering, Genomförande) plus a year dropdown. Navigation moves exactly one year at a time and can stop on uncomputed years.
+- **Year statuses**: The dropdown lists years in ascending order. Green/"Låst" marks computed years, red/"Planering" marks the active year, and grey/"Ej beräknat" marks future placeholders (year 1 is always selectable).
+- **Snapshots**: Each executed year becomes an immutable snapshot; planning changes never delete earlier snapshots.
+- **Hooks for execution**: `TimeEngine.execute_current_year` accepts a callable that can inject future calculation logic without changing UI code.
+- **Testing**: Year-based behaviour and UI hooks are covered in `tests/time/`. UI tests skip automatically when Tk is unavailable.
 
 ## Testing
 Run `pytest` in the repository root to execute the automated test suite.

--- a/tests/time/test_time_engine.py
+++ b/tests/time/test_time_engine.py
@@ -1,158 +1,69 @@
-import tkinter as tk
-
 import pytest
 
-from feodal_simulator import FeodalSimulator
-from time_engine import SEASONS, TimeEngine, TimePosition, rng_for
+from time.time_engine import TimeEngine
 
 
-def _order_processor(engine: TimeEngine, pos: TimePosition, rng):
-    key = f"{pos.year}-{pos.season}"
-    orders = engine.world_state.get("orders", {})
-    if key in orders:
-        engine.world_state["order_total"] = engine.world_state.get("order_total", 0) + orders[key]
-        engine._events.append({"type": "order_applied", "key": key, "delta": orders[key]})
+def test_year_listing_and_status():
+    engine = TimeEngine()
+    engine.record_change({"state": 1})
+
+    years = engine.list_years()
+    assert years == [1]
+    entry = engine.get_year_entries()[0]
+    assert entry.year == 1
+    assert entry.status == TimeEngine.STATUS_PLANNING
+    assert entry.selectable is True
 
 
-def test_deterministic_snapshots(tmp_path):
-    base_state = {"resource": 1}
-    engine_a = TimeEngine(
-        timeline_id="det", rng_seed=99, world_state=base_state, base_path=tmp_path / "a"
-    )
-    engine_b = TimeEngine(
-        timeline_id="det", rng_seed=99, world_state=base_state, base_path=tmp_path / "b"
-    )
+def test_navigation_sticks_on_uncomputed():
+    engine = TimeEngine()
+    engine.record_change({"state": 1})
 
-    for _ in range(8):
-        engine_a.step_seasons(1)
-        engine_b.step_seasons(1)
+    engine.next_year()
+    assert engine.current_year == 2
+    assert engine.status(2) == TimeEngine.STATUS_PLANNING
 
-    checks_a = [snap["checksum"] for snap in engine_a.snapshots]
-    checks_b = [snap["checksum"] for snap in engine_b.snapshots]
-    assert checks_a == checks_b
+    engine.prev_year()
+    assert engine.current_year == 1
+    engine.prev_year()
+    assert engine.current_year == 1
 
 
-@pytest.mark.parametrize("start_year", [0, 3])
-def test_year_vs_season_steps(tmp_path, start_year):
-    engine = TimeEngine(timeline_id=f"step-{start_year}", base_path=tmp_path)
-    engine.step_seasons(start_year * len(SEASONS))
-    pos_four = engine.step_seasons(4)
-    engine.reset_timeline(world_state=engine.world_state, timeline_id=f"step-{start_year}-b")
-    engine.step_seasons(start_year * len(SEASONS))
-    pos_year = engine.step_seasons(4)
-    assert pos_four == pos_year
-    back = engine.step_seasons(-4)
-    assert back.year == pos_four.year - 1
+def test_execute_locks_year_and_advance():
+    engine = TimeEngine()
+    engine.record_change({"val": 3})
+
+    engine.execute_current_year()
+
+    assert engine.is_computed(1) is True
+    assert engine.current_year == 2
+    assert engine.status(1) == TimeEngine.STATUS_LOCKED
+    assert engine.status(2) == TimeEngine.STATUS_PLANNING
 
 
-def test_snapshot_restore_and_orders(tmp_path):
-    state = {"orders": {"3-autumn": 5, "7-summer": 2}}
-    engine = TimeEngine(
-        timeline_id="orders", base_path=tmp_path, world_state=state, season_processors=[
-            lambda eng, pos, rng: eng._run_weather(eng, pos, rng),
-            _order_processor,
-        ]
-    )
-    target = TimePosition.from_season(3, "autumn")
-    engine.step_to(target)
-    autumn_checksum = engine.snapshots[-1]["checksum"]
-    assert engine.world_state.get("order_total", 0) == 5
-
-    engine.step_to(TimePosition.from_season(7, "summer"))
-    assert engine.world_state.get("order_total", 0) == 7
-
-    engine.step_to(target)
-    restored = next(
-        snap for snap in reversed(engine.snapshots) if snap["year"] == 3 and snap["season"] == "autumn"
-    )
-    assert restored["checksum"] == autumn_checksum
-    assert engine.world_state.get("order_total", 0) == 5
-
-
-def test_rng_for_weather_is_deterministic():
-    rng = rng_for("abc", 2, "spring", node_id=1, subsystem_tag="weather", base_seed=7)
-    vals = [rng.randint(1, 6) for _ in range(4)]
-    rng2 = rng_for("abc", 2, "spring", node_id=1, subsystem_tag="weather", base_seed=7)
-    assert vals == [rng2.randint(1, 6) for _ in range(4)]
-
-
-def test_ui_buttons_drive_time(tmp_path):
+def test_ui_controls_follow_year_navigation(monkeypatch):
     try:
-        root = tk.Tk()
-        root.withdraw()
+        import tkinter as tk
     except tk.TclError:
         pytest.skip("Tk not available")
-    sim = FeodalSimulator(root)
-    sim.time_engine.reset_timeline(world_state={}, timeline_id="ui-test", rng_seed=1)
-    sim._update_time_label(sim.time_engine.current_position)
-    sim.step_time(1)
-    assert sim.time_engine.current_position.season == "summer"
-    sim.step_time(3)
-    assert sim.time_engine.current_position.year == 1
-    assert sim.time_engine.current_position.season == "spring"
-    root.destroy()
 
+    from feodal_simulator import FeodalSimulator
 
-def test_change_in_past_truncates_future_and_replays(tmp_path):
-    def _production_processor(engine: TimeEngine, pos: TimePosition, rng):
-        rate = engine.world_state.get("rate", 1)
-        engine.world_state["stock"] = engine.world_state.get("stock", 0) + rate
-
-    engine = TimeEngine(
-        timeline_id="rewrite",
-        rng_seed=2,
-        world_state={"rate": 1},
-        base_path=tmp_path,
-        season_processors=[
-            lambda eng, pos, rng: eng._run_weather(eng, pos, rng),
-            _production_processor,
-        ],
-    )
-    end_pos = TimePosition.from_season(2, "spring")
-    engine.step_to(end_pos)
-    original_stock = engine.world_state.get("stock", 0)
-    original_weather = list(engine.world_state.get("weather_history", []))
-    change_pos = TimePosition.from_season(0, "winter")
-    change_index = change_pos.year * len(SEASONS) + change_pos.season_index
-    expected_future_weather = original_weather[change_index:]
-
-    engine.step_to(change_pos)
-    engine.world_state["rate"] = 2
-    engine.record_change(reason="production boost")
-
-    engine.step_to(end_pos)
-    assert engine.world_state.get("stock", 0) > original_stock
-    assert engine.world_state.get("weather_history", [])[change_index:] == expected_future_weather
-    assert engine.future_dirty is False
-
-
-def test_record_change_records_reason(tmp_path):
-    engine = TimeEngine(timeline_id="meta", base_path=tmp_path, world_state={"val": 1})
-    engine.world_state["val"] = 2
-    engine.record_change(reason="manual adjustment")
-    latest = engine.snapshots[-1]
-    assert latest.get("meta", {}).get("reason") == "manual adjustment"
-    assert TimePosition.from_season(latest["year"], latest["season"]) == engine.current_position
-
-
-def test_ui_disables_decade_jumps_when_future_dirty(tmp_path):
     try:
         root = tk.Tk()
-        root.withdraw()
     except tk.TclError:
         pytest.skip("Tk not available")
+    root.withdraw()
     sim = FeodalSimulator(root)
-    sim.time_engine.reset_timeline(world_state={}, timeline_id="ui-dirty", rng_seed=1)
-    sim.step_time(8)
-    sim.step_time(-4)
-    sim.mark_world_changed("past change")
+    sim.time_engine.reset_timeline(world_state={"nodes": {}}, start_year=1)
+    sim._refresh_year_dropdown()
 
-    plus_button = sim._time_jump_buttons[40]
-    minus_button = sim._time_jump_buttons[-40]
-    assert "disabled" in plus_button.state()
-    assert "disabled" in minus_button.state()
+    sim._goto_next_year()
+    assert sim.time_engine.current_year == 2
+    sim._goto_previous_year()
+    assert sim.time_engine.current_year == 1
 
-    sim.step_time(4)
-    assert "disabled" not in plus_button.state()
-    assert "disabled" not in minus_button.state()
+    sim._execute_current_year()
+    assert sim.time_engine.is_computed(1)
+    assert sim.time_engine.current_year == 2
     root.destroy()

--- a/tests/time/test_timeline_basic.py
+++ b/tests/time/test_timeline_basic.py
@@ -1,44 +1,17 @@
-import pytest
-
 from time.time_engine import TimeEngine
 
 
-def test_timeline_basic_snapshots_isolate_changes():
+def test_snapshots_are_preserved_when_planning_changes():
     engine = TimeEngine()
-    world = {"nodes": {}}
+    engine.record_change({"value": 1})
+    engine.execute_current_year()
 
-    engine.record_change(world)
-    engine.step(1)
-    world_with_building = {"nodes": {"1": {"name": "Stuga"}}}
-    engine.record_change(world_with_building)
+    assert engine.history[1]["value"] == 1
 
-    engine.goto(0, 0)
-    initial_state = engine.get_current_snapshot()
-    assert initial_state["nodes"] == {}
+    engine.prev_year()
+    past_state = engine.get_current_snapshot()
+    past_state["value"] = 2
+    engine.record_change(past_state)
 
-    engine.goto(0, 1)
-    restored = engine.get_current_snapshot()
-    assert restored["nodes"] == world_with_building["nodes"]
-
-
-def test_current_position_and_missing_snapshots():
-    engine = TimeEngine()
-    engine.record_change({"state": 1})
-
-    pos = engine.current_position
-    assert pos.year == 0
-    assert pos.season == 0
-
-    engine.step(1)
-    engine.record_change({"state": 2})
-
-    with pytest.raises(ValueError):
-        engine.goto(5, 0)
-
-
-def test_step_wraps_to_previous_year():
-    engine = TimeEngine()
-    engine.record_change({"state": "start"})
-    snapshot = engine.step(-1)
-    assert engine.current == (-1, 3)
-    assert snapshot["state"] == "start"
+    assert engine.history[1]["value"] == 1
+    assert engine.planning_state[1]["value"] == 2

--- a/tests/time/test_timeline_branching.py
+++ b/tests/time/test_timeline_branching.py
@@ -1,38 +1,14 @@
 from time.time_engine import TimeEngine
 
 
-def test_branching_removes_future_and_rebuilds():
-    engine = TimeEngine()
-    world = {"value": 0}
-    engine.record_change(world)
+def test_goto_creates_planning_state_and_respects_floor():
+    engine = TimeEngine(start_year=1)
+    engine.record_change({"v": 1})
 
-    for _ in range(10):
-        engine.step(1)
-        engine.record_change(world)
+    engine.goto(3)
+    assert engine.current_year == 3
+    assert engine.status(3) == TimeEngine.STATUS_PLANNING
+    assert 3 in engine.planning_state
 
-    engine.goto(0, 0)
-    world["value"] = 1
-    engine.record_change(world)
-
-    assert all(key <= engine.current for key in engine.history)
-    assert engine.max_future == engine.current
-    assert engine.can_jump_decade() is False
-
-    for _ in range(10):
-        snapshot = engine.step(1)
-        snapshot["value"] = engine.current[0] * 10 + engine.current[1]
-        engine.record_change(snapshot)
-
-    assert engine.max_future[0] >= 2
-    assert engine.can_jump_decade() is True
-    assert engine.history[engine.current]["value"] == engine.current[0] * 10 + engine.current[1]
-
-
-def test_reset_timeline_restarts_history():
-    engine = TimeEngine()
-    engine.record_change({"value": 1})
-    engine.step(1)
-    engine.record_change({"value": 2})
-    engine.reset_timeline(world_state={"value": 0})
-    assert engine.current == (0, 0)
-    assert engine.history[(0, 0)]["value"] == 0
+    engine.goto(0)
+    assert engine.current_year == 1

--- a/tests/time/test_weather_lock.py
+++ b/tests/time/test_weather_lock.py
@@ -11,20 +11,17 @@ def test_weather_is_locked_per_year():
     world = {}
     engine.record_change(world)
 
-    for _ in range(5 * 4):
-        snapshot = engine.step(1)
-        engine.record_change(snapshot)
+    for _ in range(4):
+        engine.execute_current_year()
 
+    engine.goto(5)
     year_five_weather = weather_lock.get_or_generate(5)
     world_with_weather = engine.get_current_snapshot()
     world_with_weather["weather"] = year_five_weather
     engine.record_change(world_with_weather)
 
-    for _ in range(5 * 4):
-        snapshot = engine.step(1)
-        engine.record_change(snapshot)
-
-    engine.goto(5, 0)
+    engine.goto(1)
+    engine.goto(5)
     returned_weather = weather_lock.get_or_generate(5)
     assert returned_weather == year_five_weather
     assert engine.get_current_snapshot()["weather"] == year_five_weather


### PR DESCRIPTION
## Summary
- replace seasonal timeline with year-based TimeEngine and statuses
- update simulator UI to use yearly dropdown plus four control buttons
- adjust documentation and tests for yearly navigation, locking, and weather handling

## Testing
- pytest tests/time

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934cbc326f4832ebd6413b2b40979cd)