### PR TITLE
Fix startup imports when running `python -m src.Feudal`

### DIFF
--- a/src/Feudal.py
+++ b/src/Feudal.py
@@ -1,6 +1,23 @@
 """Officiell startfil för feodal-simulatorn."""
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+
+def _ensure_runtime_paths() -> None:
+    """Säkerställ att både projektrot och src-katalog finns på sys.path."""
+    current_file = Path(__file__).resolve()
+    src_root = current_file.parent
+    project_root = src_root.parent
+    for path in (project_root, src_root):
+        path_str = str(path)
+        if path_str not in sys.path:
+            sys.path.insert(0, path_str)
+
+
+_ensure_runtime_paths()
+
 try:
     from src.ui import app as ui_app
 except ImportError:

--- a/tests/test_feudal_entry.py
+++ b/tests/test_feudal_entry.py
@@ -1,0 +1,14 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def test_feudal_runtime_paths_include_project_and_src():
+    module = importlib.import_module("src.Feudal")
+    module._ensure_runtime_paths()
+
+    project_root = str(Path(__file__).resolve().parent.parent)
+    src_root = str(Path(project_root) / "src")
+
+    assert project_root in sys.path
+    assert src_root in sys.path


### PR DESCRIPTION
### Motivation
- Running the app as a module (`python -m src.Feudal`) failed with `ModuleNotFoundError` for `feodal_simulator` and `ui` because the project root and `src/` were not guaranteed on `sys.path` early enough.

### Description
- Add a lightweight bootstrap `_ensure_runtime_paths()` in `src/Feudal.py` that ensures the project root and `src/` are on `sys.path` and call it at module import, and add `tests/test_feudal_entry.py` which verifies those paths are present.

### Testing
- Ran `pytest -q tests/test_feudal_entry.py tests/ui/test_app_entry.py`, which produced `2 passed, 4 skipped` and met the coverage threshold (total coverage ~42%).
- Executed `python -m src.Feudal`, which advances past the import errors but fails with `_tkinter.TclError: no display name and no $DISPLAY` in the headless environment, which is the expected outcome for a UI entrypoint in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5d581bd8832ea2a04606b608b642)