### PR TITLE
Fix NodeDetails reload crash, missing typing import, and make WeatherLock JSON-serializable

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -8,7 +8,7 @@ from tkinter import ttk, simpledialog, messagebox
 import random
 import math
 from collections import deque
-from typing import Callable, Dict
+from typing import Any, Callable, Dict
 
 from constants import (
     BORDER_TYPES,

--- a/src/time/weather_lock.py
+++ b/src/time/weather_lock.py
@@ -1,13 +1,15 @@
 import random
-from typing import Dict, Tuple
+from typing import Dict
 
 from weather import roll_weather
+
+SEASONS = ("spring", "summer", "autumn", "winter")
 
 
 class WeatherLock:
     def __init__(self):
-        # year → 4-season weather tuple
-        self.weather: Dict[int, Tuple] = {}
+        # year → season-to-weather-name mapping
+        self.weather: Dict[int, Dict[str, str]] = {}
 
     def get_or_generate(self, year: int):
         """
@@ -17,6 +19,9 @@ class WeatherLock:
 
         if year in self.weather:
             return self.weather[year]
-        generated = tuple(roll_weather(random.Random(year)) for _ in range(4))
+        rng = random.Random(year)
+        generated = {
+            season: roll_weather(season, rng=rng)[1].name for season in SEASONS
+        }
         self.weather[year] = generated
         return generated

--- a/src/ui/views/node_details_view.py
+++ b/src/ui/views/node_details_view.py
@@ -265,6 +265,18 @@ class NodeDetailsView:
                 )
 
     # --- Rendering entrypoints ---
+    def _deprecated_load_node(self, node_data) -> None:
+        print("WARNING: NodeDetailsView.load_node() är deprecated; använd show_node_view().")
+        if node_data is None:
+            self.clear()
+            return
+        self.show_node_view(node_data)
+
+    def load_node(self, node_data) -> None:
+        """Bakåtkompatibel wrapper för äldre anrop."""
+
+        self._deprecated_load_node(node_data)
+
     def show_node_view(self, node_data):
         self.app.commit_pending_changes()
         self.clear()

--- a/tests/time/test_weather_lock.py
+++ b/tests/time/test_weather_lock.py
@@ -1,4 +1,5 @@
 import random
+import json
 
 from time.time_engine import TimeEngine
 from time.weather_lock import WeatherLock
@@ -25,3 +26,13 @@ def test_weather_is_locked_per_year():
     returned_weather = weather_lock.get_or_generate(5)
     assert returned_weather == year_five_weather
     assert engine.get_current_snapshot()["weather"] == year_five_weather
+
+
+def test_weather_payload_is_json_serializable():
+    weather_lock = WeatherLock()
+    payload = weather_lock.get_or_generate(3)
+    json_blob = json.dumps(payload, ensure_ascii=False)
+
+    assert isinstance(payload, dict)
+    assert "spring" in payload
+    assert isinstance(json_blob, str)


### PR DESCRIPTION
### Motivation
- Several runtime errors were observed when advancing years: a `NameError` from a missing `Any` import, an AttributeError when the UI tried to call the removed `load_node`, and failures saving weather because `WeatherType` instances are not JSON serializable.
- The goal is to restore backward compatibility for the UI, avoid the typing error, and ensure year-locked weather is safe to persist with minimal changes.

### Description
- Added the missing `Any` import to `src/feodal_simulator.py` to satisfy type annotations used by `_execute_current_year` without changing function signatures.
- Restored a backward-compatible `load_node(node_data)` API in `src/ui/views/node_details_view.py` as a deprecated wrapper that logs a `WARNING` and delegates to the new `show_node_view(...)` entrypoint (clears when passed `None`).
- Reworked `src/time/weather_lock.py` so `get_or_generate(year)` stores a JSON-safe mapping `{

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea69b4381c832e924d6e38b29fd3fe)