### PR TITLE
Add tests to ensure invalid JSON is handled as empty worlds file

### DIFF
--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -38,6 +38,19 @@ def test_load_worlds_from_file_error(tmp_path, monkeypatch):
     assert called
 
 
+def test_load_worlds_from_file_invalid_json_returns_empty(tmp_path, monkeypatch):
+    f = tmp_path / "bad.json"
+    f.write_text('{"broken": [1, }', encoding="utf-8")
+    monkeypatch.setattr(data_manager, "DEFAULT_WORLDS_FILE", str(f))
+    called = []
+    monkeypatch.setattr(data_manager.messagebox, "showerror", lambda *a, **k: called.append(True))
+
+    result = data_manager.load_worlds_from_file()
+
+    assert result == {}
+    assert not called
+
+
 def test_save_worlds_to_file_success(tmp_path, monkeypatch):
     f = tmp_path / "out.json"
     monkeypatch.setattr(data_manager, "DEFAULT_WORLDS_FILE", str(f))

--- a/tests/test_world_interface.py
+++ b/tests/test_world_interface.py
@@ -74,6 +74,15 @@ def test_save_worlds_file_creates_directories(tmp_path):
         assert json.load(saved_file) == data
 
 
+def test_load_worlds_file_returns_empty_dict_for_invalid_json(tmp_path):
+    file_path = tmp_path / "worlds.json"
+    file_path.write_text('{"nodes": [1, 2, }', encoding="utf-8")
+
+    loaded = WorldInterface.load_worlds_file(file_path)
+
+    assert loaded == {}
+
+
 def test_validate_world_data_basic():
     world = {
         "nodes": {


### PR DESCRIPTION
### Motivation
- Ensure that invalid JSON in saved world files is treated as an empty dataset rather than raising or displaying an error when loading.

### Description
- Add unit tests `test_load_worlds_file_returns_empty_dict_for_invalid_json` (in `tests/test_world_interface.py`) and `test_load_worlds_from_file_invalid_json_returns_empty` (in `tests/test_data_manager.py`) which write malformed JSON and assert that `WorldInterface.load_worlds_file` and `data_manager.load_worlds_from_file` return `{}` and do not trigger error dialogs.

### Testing
- Ran the test suite with `pytest` and the new tests `test_load_worlds_file_returns_empty_dict_for_invalid_json` and `test_load_worlds_from_file_invalid_json_returns_empty` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea70aa3834832e97143e97a06ec339)