### PR TITLE
Switch tree view from double-click to left-click and add deprecation wrappers

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -244,7 +244,7 @@ class FeodalSimulator:
         )
         self.tree = self.structure_panel.tree
         self.structure_view = StructureView(self, self.structure_panel, self.tree)
-        self.structure_view.bind_double_click(self._handle_tree_double_click)
+        self.structure_view.bind_left_click(self._handle_tree_left_click)
         self._log_panel_event("structure", "Panel initierad")
         self.structure_panel.set_back_command(lambda: self.structure_view.set_mode("admin"))
         self.tree.bind("<<TreeviewSelect>>", self.on_tree_selection_change)
@@ -1197,13 +1197,19 @@ class FeodalSimulator:
 
         self.structure_view.set_mode("admin")
 
-    def _handle_tree_double_click(self, node_id: int) -> None:
+    def _handle_tree_left_click(self, node_id: int) -> None:
         if not self.world_data:
             return
 
         node_data = self.world_data.get("nodes", {}).get(str(node_id))
         if node_data:
             self.show_node_view(node_data)
+
+    def _deprecated_handle_tree_double_click(self, node_id: int) -> None:
+        self.add_status_message(
+            "WARNING: _handle_tree_double_click är deprecated; använd _handle_tree_left_click."
+        )
+        self._handle_tree_left_click(node_id)
 
     # --- Character Management ---
     def show_manage_characters_view(self):

--- a/src/ui/views/structure_view.py
+++ b/src/ui/views/structure_view.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import logging
 import tkinter as tk
 from typing import Callable, Iterable, Literal
+
+
+logger = logging.getLogger(__name__)
 
 
 class StructureView:
@@ -13,7 +17,7 @@ class StructureView:
         self.mode: Literal["admin", "province"] = "admin"
         self.current_province_owner_id: int | None = None
         self._admin_tree_state: dict[str, object] | None = None
-        self._double_click_callback: Callable[[int], None] | None = None
+        self._node_open_callback: Callable[[int], None] | None = None
 
     # --- Public API ---
     def capture_selection_and_expansion(self) -> dict:
@@ -148,12 +152,20 @@ class StructureView:
             except Exception:
                 pass
 
-    def bind_double_click(self, callback: Callable[[int], None]) -> None:
-        """Bind double-click events to the provided callback."""
+    def bind_left_click(self, callback: Callable[[int], None]) -> None:
+        """Bind left-click events to the provided callback."""
 
-        self._double_click_callback = callback
+        self._node_open_callback = callback
         if self._tree_exists():
-            self.tree.bind("<Double-1>", self._on_double_click)
+            self.tree.bind("<Button-1>", self._on_left_click)
+
+    def bind_double_click(self, callback: Callable[[int], None]) -> None:
+        """Deprecated wrapper for older double-click binding."""
+
+        logger.warning(
+            "WARNING: bind_double_click is deprecated; use bind_left_click instead."
+        )
+        self.bind_left_click(callback)
 
     # --- Internal rendering helpers ---
     def _render_current_view(self, restore_state: dict | None = None) -> None:
@@ -323,8 +335,8 @@ class StructureView:
         for child in subtree.get("children", []):
             self._insert_province_subtree(node_id_str, child)
 
-    # --- Double-click handling ---
-    def _on_double_click(self, _event):
+    # --- Left-click handling ---
+    def _on_left_click(self, _event):
         if not self._tree_exists() or not self.app.world_data:
             return
 
@@ -350,8 +362,16 @@ class StructureView:
             )
             return
 
-        if self._double_click_callback:
-            self._double_click_callback(node_id)
+        if self._node_open_callback:
+            self._node_open_callback(node_id)
+
+    def _deprecated_on_double_click(self, event):
+        """Deprecated wrapper for older double-click event handlers."""
+
+        logger.warning(
+            "WARNING: _on_double_click is deprecated; use _on_left_click instead."
+        )
+        return self._on_left_click(event)
 
     # --- State helpers ---
     def _tree_exists(self) -> bool:
@@ -458,4 +478,3 @@ class StructureView:
             return iid
         except tk.TclError:
             return ""
-

--- a/tests/ui/test_structure_view_left_click_binding.py
+++ b/tests/ui/test_structure_view_left_click_binding.py
@@ -1,0 +1,25 @@
+from src.ui.views.structure_view import StructureView
+
+
+class _FakeTree:
+    def __init__(self):
+        self.bindings = {}
+
+    def bind(self, event_name, callback):
+        self.bindings[event_name] = callback
+
+    def winfo_exists(self):
+        return True
+
+
+class _FakePanel:
+    pass
+
+
+def test_bind_left_click_uses_single_click_event():
+    tree = _FakeTree()
+    view = StructureView(app=object(), parent=_FakePanel(), tree_widget=tree)
+
+    view.bind_left_click(lambda _node_id: None)
+
+    assert "<Button-1>" in tree.bindings


### PR DESCRIPTION
### Motivation

- Change tree interaction from a double-click to a single left-click to simplify node opening and modernize the UX.
- Preserve backwards compatibility by keeping deprecated double-click API surface with warnings.

### Description

- Replaced double-click binding with left-click by renaming `bind_double_click` to `bind_left_click` and switching event from `"<Double-1>"` to `"<Button-1>"` in `src/ui/views/structure_view.py`.
- Renamed internal callback and handler names from `_double_click_callback`/`_on_double_click` to `_node_open_callback`/`_on_left_click` and added deprecated wrappers `bind_double_click` and `_deprecated_on_double_click` that log warnings via `logging`.
- Updated `FeodalSimulator` to use `structure_view.bind_left_click` and added a deprecated `_deprecated_handle_tree_double_click` that delegates with a warning in `src/feodal_simulator.py`.
- Added a unit test `tests/ui/test_structure_view_left_click_binding.py` to verify that `bind_left_click` registers the `"<Button-1>"` binding on the tree widget.

### Testing

- Ran the new unit test `tests/ui/test_structure_view_left_click_binding.py` which asserts `"<Button-1>"` is registered and it passed.
- Ran the unit test suite that covers `structure_view` interactions and no failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb89745314832e9c2fda1b5d6bdbf7)