### PR TITLE
Fallback to active selection or nearest existing ancestor when restoring StructureView selection; add tests

### DIFF
--- a/src/ui/views/structure_view.py
+++ b/src/ui/views/structure_view.py
@@ -66,6 +66,19 @@ class StructureView:
         focus_iid = str(focus_id) if focus_id is not None else None
         lineage = self._lineage(focus_iid)
 
+        if focus_iid is None:
+            active_selection = tuple(self.tree.selection())
+            if active_selection:
+                focus_iid = active_selection[0]
+                lineage = self._lineage(focus_iid)
+            else:
+                fallback_target, fallback_lineage = self._selection_fallback_target(
+                    selection
+                )
+                if fallback_target is not None:
+                    focus_iid = fallback_target
+                    lineage = fallback_lineage
+
         for ancestor in lineage:
             self._open_iid(ancestor)
         if focus_iid:
@@ -397,6 +410,16 @@ class StructureView:
                 self.tree.see(valid_selection[0])
         except tk.TclError:
             print("Warning: Could not fully restore tree selection (items might have changed).")
+
+    def _selection_fallback_target(
+        self, selection: Iterable[str]
+    ) -> tuple[str | None, list[str]]:
+        for selected_iid in selection:
+            lineage = self._lineage(selected_iid)
+            for ancestor in reversed(lineage):
+                if self.tree.exists(ancestor):
+                    return ancestor, lineage
+        return None, []
 
     def _lineage(self, node_id: str | None) -> list[str]:
         if node_id is None:

--- a/tests/ui/test_structure_view_selection_restore.py
+++ b/tests/ui/test_structure_view_selection_restore.py
@@ -1,0 +1,96 @@
+from src.ui.views.structure_view import StructureView
+
+
+class _FakeTree:
+    def __init__(self):
+        self.nodes = {
+            "1": {"children": ["2"], "open": False},
+            "2": {"children": ["3"], "open": False},
+            "3": {"children": [], "open": False},
+        }
+        self._selection = ()
+        self._focus = ""
+        self.last_seen = ""
+
+    def winfo_exists(self):
+        return True
+
+    def get_children(self, item_id=""):
+        if item_id == "":
+            children = []
+            for node_id in self.nodes:
+                if self.parent(node_id) is None:
+                    children.append(node_id)
+            return tuple(children)
+        node = self.nodes.get(item_id)
+        if not node:
+            return ()
+        return tuple(node["children"])
+
+    def parent(self, node_id):
+        for parent_id, node in self.nodes.items():
+            if node_id in node["children"]:
+                return parent_id
+        return None
+
+    def item(self, item_id, option=None, **kwargs):
+        node = self.nodes[item_id]
+        if "open" in kwargs:
+            node["open"] = kwargs["open"]
+        if option == "open":
+            return node["open"]
+        return node
+
+    def exists(self, item_id):
+        return item_id in self.nodes
+
+    def selection(self):
+        return self._selection
+
+    def selection_set(self, selection):
+        if isinstance(selection, tuple):
+            self._selection = selection
+        else:
+            self._selection = (selection,)
+
+    def focus(self, item_id=None):
+        if item_id is not None:
+            self._focus = item_id
+        return self._focus
+
+    def see(self, item_id):
+        self.last_seen = item_id
+
+
+class _FakePanel:
+    pass
+
+
+class _FakeApp:
+    def __init__(self):
+        self.world_data = {
+            "nodes": {
+                "1": {"parent_id": None},
+                "2": {"parent_id": 1},
+                "3": {"parent_id": 2},
+            }
+        }
+
+
+def test_restore_keeps_existing_selection():
+    tree = _FakeTree()
+    view = StructureView(app=_FakeApp(), parent=_FakePanel(), tree_widget=tree)
+
+    view.restore_selection_and_expansion({"open_items": set(), "selection": ("2",)})
+
+    assert tree.selection() == ("2",)
+
+
+def test_restore_selects_nearest_parent_when_selected_node_is_missing():
+    tree = _FakeTree()
+    tree.nodes.pop("3")
+    view = StructureView(app=_FakeApp(), parent=_FakePanel(), tree_widget=tree)
+
+    view.restore_selection_and_expansion({"open_items": set(), "selection": ("3",)})
+
+    assert tree.selection() == ("2",)


### PR DESCRIPTION
### Motivation
- Ensure the tree restores a sensible focus/selection when the requested focus node is missing or not provided.
- Prevent losing user context by preferring the current active selection or the nearest existing ancestor of a missing selection.

### Description
- Update `restore_selection_and_expansion` to, when `focus_id` is `None`, prefer the current active tree selection and otherwise fall back to a nearest existing ancestor derived from the saved `selection`.
- Add `_selection_fallback_target` helper to locate the nearest existing ancestor for a given saved selection.
- Keep existing behavior of expanding ancestors and handling `expand_to_owner_anchor`, and preserve existing `TclError` guards.
- Add unit tests in `tests/ui/test_structure_view_selection_restore.py` with fake tree/app objects to validate selection restoration behavior.

### Testing
- Ran the new unit tests `tests/ui/test_structure_view_selection_restore.py` which include `test_restore_keeps_existing_selection` and `test_restore_selects_nearest_parent_when_selected_node_is_missing`, and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba0bb2ee4832e8393cbfcd6e5c6d8)