### PR TITLE
Fix tree node activation on single left click

### DIFF
--- a/src/ui/views/structure_view.py
+++ b/src/ui/views/structure_view.py
@@ -349,11 +349,17 @@ class StructureView:
             self._insert_province_subtree(node_id_str, child)
 
     # --- Left-click handling ---
-    def _on_left_click(self, _event):
+    def _on_left_click(self, event):
         if not self._tree_exists() or not self.app.world_data:
             return
 
-        item_id_str = self.tree.focus()
+        item_id_str = ""
+        if event is not None and hasattr(event, "y") and hasattr(self.tree, "identify_row"):
+            item_id_str = self.tree.identify_row(event.y)
+
+        if not item_id_str:
+            item_id_str = self.tree.focus()
+
         if not item_id_str:
             return
 
@@ -367,6 +373,12 @@ class StructureView:
             node_id = int(item_id_str)
         except (TypeError, ValueError):
             return
+
+        try:
+            self.tree.selection_set(item_id_str)
+            self.tree.focus(item_id_str)
+        except Exception:
+            pass
 
         node_data = (self.app.world_data or {}).get("nodes", {}).get(item_id_str)
         if not node_data:

--- a/tests/ui/test_structure_view_left_click_binding.py
+++ b/tests/ui/test_structure_view_left_click_binding.py
@@ -16,6 +16,38 @@ class _FakePanel:
     pass
 
 
+class _FakeApp:
+    def __init__(self):
+        self.world_data = {"nodes": {"2": {"node_id": 2}}}
+
+    def add_status_message(self, _msg):
+        pass
+
+
+class _FakeInteractiveTree(_FakeTree):
+    def __init__(self):
+        super().__init__()
+        self._focus = "1"
+        self._selection = ()
+
+    def identify_row(self, y):
+        return "2" if y == 22 else ""
+
+    def focus(self, item=None):
+        if item is not None:
+            self._focus = item
+        return self._focus
+
+    def selection_set(self, item):
+        self._selection = (item,)
+
+    def selection(self):
+        return self._selection
+
+    def exists(self, item):
+        return item in {"1", "2"}
+
+
 def test_bind_left_click_uses_single_click_event():
     tree = _FakeTree()
     view = StructureView(app=object(), parent=_FakePanel(), tree_widget=tree)
@@ -23,3 +55,18 @@ def test_bind_left_click_uses_single_click_event():
     view.bind_left_click(lambda _node_id: None)
 
     assert "<Button-1>" in tree.bindings
+
+
+def test_left_click_activates_clicked_node_without_second_click():
+    tree = _FakeInteractiveTree()
+    app = _FakeApp()
+    view = StructureView(app=app, parent=_FakePanel(), tree_widget=tree)
+    opened = []
+    view.bind_left_click(lambda node_id: opened.append(node_id))
+
+    event = type("E", (), {"y": 22})()
+    view._on_left_click(event)
+
+    assert opened == [2]
+    assert tree.selection() == ("2",)
+    assert tree.focus() == "2"


### PR DESCRIPTION
### Motivation
- Users currently must double-click a node in the tree to activate it because the click handler relied on stale focus instead of the actual row under the mouse, so a fix ensures a single left-click activates the clicked node.
- Keep the change minimal and local to the UI view without touching core systems or admin-mode behavior.

### Description
- Resolve the clicked row from the mouse event using `tree.identify_row(event.y)` and fall back to `tree.focus()` if needed in `StructureView._on_left_click` in `src/ui/views/structure_view.py`.
- Explicitly call `tree.selection_set(...)` and `tree.focus(...)` for the clicked item before invoking the open callback so selection and focus are synced on first click.
- Preserve deprecated double-click wrapper behavior and keep all changes scoped to `StructureView` only.
- Add a focused UI test `test_left_click_activates_clicked_node_without_second_click` in `tests/ui/test_structure_view_left_click_binding.py` using small fakes to assert the callback, selection, and focus are set by a single left click.

### Testing
- Ran `pytest -q tests/ui/test_structure_view_left_click_binding.py` which executed the two tests in the file; both test cases passed but the run failed the repository coverage gate (project config enforces coverage fail-under), so test assertions themselves succeeded.
- Ran `pytest -q --no-cov tests/ui/test_structure_view_left_click_binding.py` which reported `2 passed` and succeeded.
- Diffstat: `src/ui/views/structure_view.py` (+16/ -2) and `tests/ui/test_structure_view_left_click_binding.py` (+47/ -0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba5de5ea8832ebae590d821a3dc21)