### PR TITLE
Restore tree and focus parent after node deletion; add unit test

### DIFF
--- a/src/feodal_simulator.py
+++ b/src/feodal_simulator.py
@@ -1872,9 +1872,10 @@ class FeodalSimulator:
                     f"Raderade nod '{display_name}' (ID: {node_id}) och {deleted_count_total-1} underliggande nod(er)."
                 )
 
-                # Refresh the entire tree efficiently
-                self.structure_view.rebuild_full_tree()
-                self.structure_view.restore_selection_and_expansion(state_snapshot)
+                # Refresh the entire tree efficiently and keep context near deletion.
+                self._restore_tree_after_delete(
+                    state_snapshot=state_snapshot, parent_id=parent_id
+                )
 
                 self.show_no_world_view()  # Clear the right panel
 
@@ -1885,6 +1886,16 @@ class FeodalSimulator:
             style="Danger.TButton",
         )
         return delete_button
+
+    def _restore_tree_after_delete(
+        self, state_snapshot: dict | None, parent_id: int | str | None
+    ) -> None:
+        """Rebuild tree and focus nearest remaining context after a delete."""
+
+        self.structure_view.rebuild_full_tree()
+        self.structure_view.restore_selection_and_expansion(
+            state_snapshot, focus_id=parent_id
+        )
 
     @staticmethod
     def _has_dagsverken_changed(node_data, new_value):

--- a/tests/test_feodal_simulator.py
+++ b/tests/test_feodal_simulator.py
@@ -1441,3 +1441,23 @@ def test_open_character_creator_for_node_spouse_inherits_surname_and_gender():
     assert new_char["gender"] == "Kvinna"
     assert new_char["name"].endswith("Test")
     assert context["inherit_surname"] is True
+
+
+def test_restore_tree_after_delete_focuses_parent_node():
+    sim = fs.FeodalSimulator.__new__(fs.FeodalSimulator)
+    calls = {"rebuild": 0, "restore": []}
+
+    class _StructureViewSpy:
+        def rebuild_full_tree(self):
+            calls["rebuild"] += 1
+
+        def restore_selection_and_expansion(self, state, **kwargs):
+            calls["restore"].append((state, kwargs))
+
+    sim.structure_view = _StructureViewSpy()
+
+    snapshot = {"open_items": {"1"}, "selection": ("3",)}
+    sim._restore_tree_after_delete(snapshot, parent_id=2)
+
+    assert calls["rebuild"] == 1
+    assert calls["restore"] == [(snapshot, {"focus_id": 2})]


### PR DESCRIPTION
### Motivation

- Ensure the tree view is rebuilt after deleting a node while restoring selection/expansion and focusing the nearest remaining context (the parent) for better UX and maintainability.

### Description

- Extracted the tree refresh and context restore logic into a new helper method `FeodalSimulator._restore_tree_after_delete(state_snapshot, parent_id)` that calls `structure_view.rebuild_full_tree()` and `structure_view.restore_selection_and_expansion(state_snapshot, focus_id=parent_id)`.
- Replaced inline rebuild/restore code in the delete flow to call the new `_restore_tree_after_delete` helper for clearer intent and reuse.
- Added type hints and a short docstring to the new helper to document behavior.
- Added a unit test `test_restore_tree_after_delete_focuses_parent_node` to verify that the helper calls `rebuild_full_tree` once and invokes `restore_selection_and_expansion` with the provided snapshot and `focus_id` equal to the parent id.

### Testing

- Ran `pytest tests/test_feodal_simulator.py` and the test file passed, including `test_restore_tree_after_delete_focuses_parent_node`.
- Existing tests in the file remained green after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebace15c70832eb351a873a4cc152a)