### PR TITLE
Add presentation-only notebook to NodeDetailsView

### DIFF
--- a/src/ui/views/node_details_view.py
+++ b/src/ui/views/node_details_view.py
@@ -12,6 +12,12 @@ from utils import ScrollableFrame
 class NodeDetailsView:
     """Ansvarar för rendering och interaktion i detaljpanelen."""
 
+    _NOTEBOOK_TABS = {
+        "upper": "Vasaller & bidrag",
+        "domain": "Domänöversikt",
+        "management": "Förvaltning",
+    }
+
     def __init__(self, app, details_panel, status_service, event_bus):
         self.app = app
         self.details_panel = details_panel
@@ -277,6 +283,14 @@ class NodeDetailsView:
 
         self._deprecated_load_node(node_data)
 
+    @classmethod
+    def _notebook_tab_for_depth(cls, depth: int) -> str:
+        if depth <= 2:
+            return cls._NOTEBOOK_TABS["upper"]
+        if depth == 3:
+            return cls._NOTEBOOK_TABS["domain"]
+        return cls._NOTEBOOK_TABS["management"]
+
     def show_node_view(self, node_data):
         self.app.commit_pending_changes()
         self.clear()
@@ -315,7 +329,12 @@ class NodeDetailsView:
             title_frame, text=f" (ID: {node_id}, Djup: {depth})", font=("Arial", 10)
         ).pack(side=tk.LEFT, anchor="s", padx=5)
 
-        scroll_frame = self.create_details_scrollable_frame(view_frame)
+        notebook = ttk.Notebook(view_frame)
+        notebook.pack(fill="both", expand=True)
+        editor_tab = ttk.Frame(notebook)
+        notebook.add(editor_tab, text=self._notebook_tab_for_depth(depth))
+
+        scroll_frame = self.create_details_scrollable_frame(editor_tab)
         scroll_frame.pack(fill="both", expand=True)
         editor_content_frame = scroll_frame.content
 

--- a/tests/ui/test_node_details_notebook.py
+++ b/tests/ui/test_node_details_notebook.py
@@ -1,0 +1,126 @@
+import tkinter as tk
+from tkinter import ttk
+
+import pytest
+
+from src.ui import app as ui_app
+from ui.views.node_details_view import NodeDetailsView
+
+
+@pytest.fixture
+def root():
+    try:
+        tk_root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk-display saknas, hoppar över UI-test")
+    tk_root.withdraw()
+    yield tk_root
+    tk_root.destroy()
+
+
+def _build_world():
+    return {
+        "nodes": {
+            str(node_id): {
+                "node_id": node_id,
+                "parent_id": node_id - 1 if node_id > 1 else None,
+                "children": [node_id + 1] if node_id < 5 else [],
+            }
+            for node_id in range(1, 6)
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    ("depth", "expected_tab"),
+    [
+        (0, "Vasaller & bidrag"),
+        (1, "Vasaller & bidrag"),
+        (2, "Vasaller & bidrag"),
+        (3, "Domänöversikt"),
+        (4, "Förvaltning"),
+        (7, "Förvaltning"),
+    ],
+)
+def test_notebook_tab_label_for_depth(depth, expected_tab):
+    assert NodeDetailsView._notebook_tab_for_depth(depth) == expected_tab
+
+
+def _find_notebook(widget):
+    for child in widget.winfo_children():
+        if isinstance(child, ttk.Notebook):
+            return child
+        notebook = _find_notebook(child)
+        if notebook is not None:
+            return notebook
+    return None
+
+
+def _is_descendant(widget, ancestor):
+    current = widget
+    while current is not None:
+        if current is ancestor:
+            return True
+        current = current.master
+    return False
+
+
+@pytest.mark.parametrize(
+    ("node_id", "expected_tab", "expected_editor"),
+    [
+        (1, "Vasaller & bidrag", "upper"),
+        (2, "Vasaller & bidrag", "upper"),
+        (3, "Vasaller & bidrag", "upper"),
+        (4, "Domänöversikt", "jarldome"),
+        (5, "Förvaltning", "resource"),
+    ],
+)
+def test_node_depth_uses_notebook_tab_and_calls_editor_once(
+    root, monkeypatch, node_id, expected_tab, expected_editor
+):
+    app = ui_app.create_app(root)
+    app.world_data = _build_world()
+    app.world_manager.set_world_data(app.world_data)
+    editor_calls = []
+
+    monkeypatch.setattr(
+        app,
+        "_show_upper_level_node_editor",
+        lambda parent, node, depth: editor_calls.append(("upper", parent)),
+    )
+    monkeypatch.setattr(
+        app,
+        "_show_jarldome_editor",
+        lambda parent, node: editor_calls.append(("jarldome", parent)),
+    )
+    monkeypatch.setattr(
+        app,
+        "_show_resource_editor",
+        lambda parent, node, depth: editor_calls.append(("resource", parent)),
+    )
+
+    app.show_node_view(app.world_data["nodes"][str(node_id)])
+
+    notebook = _find_notebook(app.details_panel.body)
+    assert notebook is not None
+    assert [notebook.tab(tab_id, "text") for tab_id in notebook.tabs()] == [
+        expected_tab
+    ]
+    assert [editor for editor, _parent in editor_calls] == [expected_editor]
+    tab_frame = notebook.nametowidget(notebook.tabs()[0])
+    assert _is_descendant(editor_calls[0][1], tab_frame)
+
+
+def test_level_three_owner_dropdown_remains_outside_notebook(root):
+    app = ui_app.create_app(root)
+    app.world_data = _build_world()
+    app.world_manager.set_world_data(app.world_data)
+
+    app.show_node_view(app.world_data["nodes"]["4"])
+
+    notebook = _find_notebook(app.details_panel.body)
+    assert notebook is not None
+    assert app.details_panel.ownership_frame.winfo_manager()
+    assert app.details_panel.ownership_frame.master is app.details_panel.body.master
+    assert not _is_descendant(app.details_panel.ownership_frame, notebook)
+    assert app.details_panel.ownership_combobox.instate(["readonly"])


### PR DESCRIPTION
### Motivation
- Implement a presentation-only tabbed view in `NodeDetailsView` (Step A) so the existing editors are shown inside a depth-specific `ttk.Notebook` without changing domain, tax, ownership, or province logic.

### Description
- Add a `_NOTEBOOK_TABS` mapping and a helper `NodeDetailsView._notebook_tab_for_depth(depth)` to select tab labels: depths 0–2 => "Vasaller & bidrag", depth 3 => "Domänöversikt", depth 4+ => "Förvaltning".
- Insert a single `ttk.Notebook` in the details view and render the existing scrollable editor inside the notebook's tab chosen by depth while preserving existing editor call sites and signatures.
- Keep the ownership combobox/frame rendered outside/above the notebook and continue to call `update_ownership_controls` prior to building the notebook so ownership behavior is unchanged.
- Add `tests/ui/test_node_details_notebook.py` containing focused tests for the tab label logic, that exactly one editor invocation occurs, that the editor is placed inside the notebook tab, and that the level-3 ownership dropdown remains outside the notebook.

### Testing
- Ran the full test suite with `python -m pytest -q`, which completed successfully with `237 passed, 68 skipped, 1 warning`.
- Ran the focused UI tests with `python -m pytest -q tests/ui/test_node_details_notebook.py`, which resulted in `6 passed, 6 skipped` where UI tests were skipped in headless situations with the message that the Tk display is missing.
- Verified `python -m py_compile src/ui/views/node_details_view.py tests/ui/test_node_details_notebook.py` and performed lint/format checks; `node_details_view.py` would be reformatted by `black` but was left as-is to keep the diff minimal.
- Diffstat: 2 files changed, 146 insertions(+), 1 deletion(-); changed files are `src/ui/views/node_details_view.py` and `tests/ui/test_node_details_notebook.py`.
- Confirmed no changes were made to tree view, province-mode behavior, `world_manager`, domain logic, tax calculations, ownership model, rollup/summarization logic, JSON/schema, or existing editor signatures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ec8f4ed40832ea8f8239033720511)