### PR TITLE
Korrigera notebook-flikar i nod-detaljvyn

### DIFF
--- a/src/ui/views/node_details_view.py
+++ b/src/ui/views/node_details_view.py
@@ -12,6 +12,8 @@ from utils import ScrollableFrame
 class NodeDetailsView:
     """Ansvarar för rendering och interaktion i detaljpanelen."""
 
+    _EDITOR_TAB = "Redigering"
+    _PRESENTATION_PLACEHOLDER = "Denna översikt är inte implementerad ännu."
     _NOTEBOOK_TABS = {
         "upper": "Vasaller & bidrag",
         "domain": "Domänöversikt",
@@ -332,7 +334,17 @@ class NodeDetailsView:
         notebook = ttk.Notebook(view_frame)
         notebook.pack(fill="both", expand=True)
         editor_tab = ttk.Frame(notebook)
-        notebook.add(editor_tab, text=self._notebook_tab_for_depth(depth))
+        notebook.add(editor_tab, text=self._EDITOR_TAB)
+        presentation_tab = ttk.Frame(notebook)
+        notebook.add(
+            presentation_tab,
+            text=self._notebook_tab_for_depth(depth),
+        )
+        ttk.Label(
+            presentation_tab,
+            text=self._PRESENTATION_PLACEHOLDER,
+            padding=10,
+        ).pack(anchor="nw")
 
         scroll_frame = self.create_details_scrollable_frame(editor_tab)
         scroll_frame.pack(fill="both", expand=True)

--- a/tests/ui/test_node_details_notebook.py
+++ b/tests/ui/test_node_details_notebook.py
@@ -75,7 +75,7 @@ def _is_descendant(widget, ancestor):
         (5, "Förvaltning", "resource"),
     ],
 )
-def test_node_depth_uses_notebook_tab_and_calls_editor_once(
+def test_node_depth_uses_editing_and_presentation_tabs_and_calls_editor_once(
     root, monkeypatch, node_id, expected_tab, expected_editor
 ):
     app = ui_app.create_app(root)
@@ -104,11 +104,34 @@ def test_node_depth_uses_notebook_tab_and_calls_editor_once(
     notebook = _find_notebook(app.details_panel.body)
     assert notebook is not None
     assert [notebook.tab(tab_id, "text") for tab_id in notebook.tabs()] == [
-        expected_tab
+        "Redigering",
+        expected_tab,
     ]
     assert [editor for editor, _parent in editor_calls] == [expected_editor]
     tab_frame = notebook.nametowidget(notebook.tabs()[0])
     assert _is_descendant(editor_calls[0][1], tab_frame)
+    presentation_frame = notebook.nametowidget(notebook.tabs()[1])
+    assert not _is_descendant(editor_calls[0][1], presentation_frame)
+
+
+def test_presentation_tab_contains_only_placeholder(root, monkeypatch):
+    app = ui_app.create_app(root)
+    app.world_data = _build_world()
+    app.world_manager.set_world_data(app.world_data)
+
+    monkeypatch.setattr(app, "_show_jarldome_editor", lambda parent, node: None)
+
+    app.show_node_view(app.world_data["nodes"]["4"])
+
+    notebook = _find_notebook(app.details_panel.body)
+    presentation_frame = notebook.nametowidget(notebook.tabs()[1])
+    presentation_widgets = presentation_frame.winfo_children()
+    assert len(presentation_widgets) == 1
+    assert isinstance(presentation_widgets[0], ttk.Label)
+    assert (
+        presentation_widgets[0].cget("text")
+        == NodeDetailsView._PRESENTATION_PLACEHOLDER
+    )
 
 
 def test_level_three_owner_dropdown_remains_outside_notebook(root):


### PR DESCRIPTION
### Motivation

- Den befintliga implementationen placerade editorn i en enda djupberoende flik, vilket var semantiskt fel och försvårade att lägga till en presentationsvy per nod.
- Målet är att varje nod ska ha en oförändrad "Redigering"-flik för den befintliga editorn och en separat presentationsflik (djupberoende) som i denna omgång endast visar en placeholder.

### Description

- Introducerar en dedikerad editor-flik genom att lägga till `_EDITOR_TAB = "Redigering"` i `NodeDetailsView` och skapa en andra flik för presentation i `show_node_view` utan att ändra editorlogik eller signaturer.
- Lägger till `_PRESENTATION_PLACEHOLDER = "Denna översikt är inte implementerad ännu."` och renderar den som ensam `ttk.Label` i presentationsfliken.
- Preserverar befintliga anrop till `_show_upper_level_node_editor`, `_show_jarldome_editor` och `_show_resource_editor` så att editorn renderas oförändrat i `Redigering`-fliken.
- Uppdaterar och utökar UI-testerna i `tests/ui/test_node_details_notebook.py` för att verifiera både "Redigering"- och presentationsfliken, editorplacering och att presentationsfliken endast innehåller placeholder.

### Testing

- Körbarhetskontroll med `python -m py_compile src/ui/views/node_details_view.py tests/ui/test_node_details_notebook.py` lyckades.
- Fokuserade UI-tester med `pytest -q tests/ui/test_node_details_notebook.py` resulterade i `6 passed, 7 skipped` (Tk-display saknades i headless-miljön, skippade UI-tester är förväntat).
- Hela testsviten med `pytest -q` kördes och gav `237 passed, 69 skipped` med en befintlig varning; testsviten godkändes.
- Diffstat: 2 filer ändrade, 38 insättningar, 3 borttagningar; ändringarna är avgränsade till `src/ui/views/node_details_view.py` och `tests/ui/test_node_details_notebook.py` och påverkar inte world_manager, JSON/schema, skatteberäkningar, ägarmodell, rollup-logik, trädvyn eller province-mode.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ed417e734832ebb5c59378eb5979e)