### PR TITLE
Add read-only “Vasaller & bidrag” (Vassals & Contributions) overview for depths 0–2

### DIFF
--- a/src/ui/views/node_details_view.py
+++ b/src/ui/views/node_details_view.py
@@ -393,6 +393,79 @@ class NodeDetailsView:
             ),
         )
 
+    def _show_vassals_overview(
+        self, parent: tk.Misc, node_data: dict, depth: int, display_name: str
+    ) -> None:
+        node_id = node_data["node_id"]
+        nodes = (self.app.world_data or {}).get("nodes", {})
+        children = [
+            nodes[str(child_id)]
+            for child_id in node_data.get("children", [])
+            if str(child_id) in nodes
+        ]
+        child_depths = Counter(
+            self.app.get_depth_of_node(child["node_id"]) for child in children
+        )
+
+        summary_rows = [
+            ("Namn", display_name),
+            ("Nivå", depth),
+            ("Direkta undernoder", len(children)),
+        ]
+        summary_rows.extend(
+            (f"Direkta undernoder på nivå {child_depth}", count)
+            for child_depth, count in sorted(child_depths.items())
+        )
+        self._add_overview_section(parent, "Sammanfattning", summary_rows)
+
+        child_rows = []
+        for child in children:
+            child_depth = self.app.get_depth_of_node(child["node_id"])
+            child_name = self.app.get_display_name_for_node(child, child_depth)
+            child_type = child.get("res_type") or "Saknas ännu"
+            child_rows.append(
+                (
+                    child_name,
+                    (
+                        f"Nivå {child_depth}; direkta barn: "
+                        f"{len(child.get('children', []))}; typ: {child_type}"
+                    ),
+                )
+            )
+        self._add_overview_section(
+            parent,
+            "Underliggande områden",
+            child_rows or [("Områden", "Saknas ännu")],
+        )
+        self._add_overview_section(
+            parent,
+            "Skatt",
+            (("Status", "Ny skattefördelning är inte implementerad ännu."),),
+        )
+
+        soldiers = self.app.world_manager.aggregate_resources(node_id)["soldiers"]
+        soldier_rows = sorted(soldiers.items()) or [
+            ("Rapporterade soldater", "Saknas ännu")
+        ]
+        self._add_overview_section(parent, "Soldater", soldier_rows)
+
+        status_rows = [
+            ("Umbärande", self.app.world_manager.calculate_umbarande(node_id)),
+            ("Befolkning", node_data.get("population", "Saknas ännu")),
+            ("Vädereffekt", node_data.get("weather_effect", "Saknas ännu")),
+        ]
+        self._add_overview_section(parent, "Status & risk", status_rows)
+        self._add_overview_section(
+            parent,
+            "Flaggor",
+            (("Status", "Flaggor är inte implementerade ännu."),),
+        )
+        self._add_overview_section(
+            parent,
+            "Åtgärder",
+            (("Status", "Åtgärder är inte implementerade ännu."),),
+        )
+
     def show_node_view(self, node_data):
         self.app.commit_pending_changes()
         self.clear()
@@ -446,12 +519,17 @@ class NodeDetailsView:
         scroll_frame.pack(fill="both", expand=True)
         editor_content_frame = scroll_frame.content
         presentation_scroll = None
-        if depth == 3:
+        if 0 <= depth <= 3:
             presentation_scroll = self.create_details_scrollable_frame(presentation_tab)
             presentation_scroll.pack(fill="both", expand=True)
-            self._show_domain_overview(
-                presentation_scroll.content, node_data, depth, display_name
-            )
+            if depth <= 2:
+                self._show_vassals_overview(
+                    presentation_scroll.content, node_data, depth, display_name
+                )
+            else:
+                self._show_domain_overview(
+                    presentation_scroll.content, node_data, depth, display_name
+                )
         else:
             ttk.Label(
                 presentation_tab,

--- a/tests/ui/test_node_details_notebook.py
+++ b/tests/ui/test_node_details_notebook.py
@@ -170,6 +170,49 @@ def test_domain_overview_handles_missing_optional_values(root, monkeypatch):
     assert "Saknas ännu" in _descendant_texts(presentation_frame)
 
 
+@pytest.mark.parametrize("node_id", [1, 2, 3])
+def test_vassals_overview_contains_read_only_sections(root, monkeypatch, node_id):
+    app = ui_app.create_app(root)
+    app.world_data = _build_world()
+    app.world_manager.set_world_data(app.world_data)
+    monkeypatch.setattr(
+        app, "_show_upper_level_node_editor", lambda parent, node, depth: None
+    )
+
+    app.show_node_view(app.world_data["nodes"][str(node_id)])
+
+    notebook = _find_notebook(app.details_panel.body)
+    presentation_frame = notebook.nametowidget(notebook.tabs()[1])
+    texts = _descendant_texts(presentation_frame)
+    assert {
+        "Sammanfattning",
+        "Underliggande områden",
+        "Skatt",
+        "Soldater",
+        "Status & risk",
+        "Flaggor",
+        "Åtgärder",
+    }.issubset(texts)
+    assert not _descendants_of_type(
+        presentation_frame, (ttk.Entry, ttk.Combobox, ttk.Spinbox)
+    )
+
+
+def test_vassals_overview_handles_missing_optional_values(root, monkeypatch):
+    app = ui_app.create_app(root)
+    app.world_data = _build_world()
+    app.world_manager.set_world_data(app.world_data)
+    monkeypatch.setattr(
+        app, "_show_upper_level_node_editor", lambda parent, node, depth: None
+    )
+
+    app.show_node_view(app.world_data["nodes"]["1"])
+
+    notebook = _find_notebook(app.details_panel.body)
+    presentation_frame = notebook.nametowidget(notebook.tabs()[1])
+    assert "Saknas ännu" in _descendant_texts(presentation_frame)
+
+
 def test_level_three_owner_dropdown_remains_outside_notebook(root):
     app = ui_app.create_app(root)
     app.world_data = _build_world()


### PR DESCRIPTION
### Motivation

- Provide a first read-only presentation of vasals and contributions for hierarchy depths 0–2 without introducing any new domain logic or changing existing rollup/aggregation behavior.  
- Reuse the existing read-only presentation pattern used by the depth-3 `Domänöversikt` to keep UI/scrolling/editor placement behavior consistent.  
- Ensure the view only surfaces values that already exist in the codebase and show clear placeholders where new tax/flag/action logic would be required.

### Description

- Added a new read-only renderer `_show_vassals_overview(...)` in `src/ui/views/node_details_view.py` that renders the requested sections: `Sammanfattning`, `Underliggande områden`, `Skatt`, `Soldater`, `Status & risk`, `Flaggor`, and `Åtgärder`.  
- Hooked the new renderer into `NodeDetailsView.show_node_view()` so that depths `0–2` display the new scrollable presentations area while preserving the `Redigering` tab and its editor placement.  
- The view uses only existing data and functions (`get_display_name_for_node`, `get_depth_of_node`, node `children`, `res_type`, `aggregate_resources(node_id)[

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2efb516974832ebd93a9ddd0f3a980)