### PR TITLE
Lägg till read-only "Förvaltning" vy för djup 4+ noder

### DIFF
--- a/src/ui/views/node_details_view.py
+++ b/src/ui/views/node_details_view.py
@@ -466,6 +466,101 @@ class NodeDetailsView:
             (("Status", "Åtgärder är inte implementerade ännu."),),
         )
 
+    def _show_management_overview(
+        self, parent: tk.Misc, node_data: dict, depth: int, display_name: str
+    ) -> None:
+        nodes = (self.app.world_data or {}).get("nodes", {})
+        children = [
+            nodes[str(child_id)]
+            for child_id in node_data.get("children", [])
+            if str(child_id) in nodes
+        ]
+        child_types = Counter(
+            child.get("res_type") or "Saknas ännu" for child in children
+        )
+
+        summary_rows = [
+            ("Namn", display_name),
+            ("Nivå", depth),
+            ("Resurstyp", node_data.get("res_type") or "Saknas ännu"),
+            ("Direkta undernoder", len(children)),
+        ]
+        if "population" in node_data:
+            summary_rows.append(("Befolkning", node_data["population"]))
+        self._add_overview_section(parent, "Sammanfattning", summary_rows)
+        self._add_overview_section(
+            parent,
+            "Förvaltare",
+            (("Status", "Förvaltarmodell är inte implementerad ännu."),),
+        )
+        self._add_overview_section(
+            parent,
+            "Assistenter",
+            (("Status", "Assistenter är inte implementerade ännu."),),
+        )
+
+        responsibility_rows = [("Direkta undernoder", len(children))]
+        responsibility_rows.extend(sorted(child_types.items()))
+        self._add_overview_section(parent, "Ansvarsområde", responsibility_rows)
+
+        storage_fields = (
+            ("BAS", "storage_basic"),
+            ("Lyx", "storage_luxury"),
+            ("Silver", "storage_silver"),
+            ("Timmer", "storage_timber"),
+            ("Kol", "storage_coal"),
+            ("Järnmalm", "storage_iron_ore"),
+            ("Järn", "storage_iron"),
+            ("Djurfoder", "storage_animal_feed"),
+            ("Skinn", "storage_skin"),
+        )
+        storage_rows = [
+            (label, node_data[field])
+            for label, field in storage_fields
+            if field in node_data
+        ]
+        self._add_overview_section(
+            parent,
+            "Resurser & lager",
+            storage_rows or [("Status", "Ingen säker datakälla")],
+        )
+        self._add_overview_section(
+            parent,
+            "Arbete/DV",
+            (
+                (
+                    "Status",
+                    "DV-sammanfattning saknar säker datakälla för denna nod.",
+                ),
+            ),
+        )
+        self._add_overview_section(
+            parent,
+            "Inkomstutmaning",
+            (("Status", "Inkomstutmaningar är inte implementerade ännu."),),
+        )
+        self._add_overview_section(
+            parent,
+            "Kostnader",
+            (("Status", "Förvaltningskostnader är inte implementerade ännu."),),
+        )
+        modifier_rows = (
+            [("Vädereffekt", node_data["weather_effect"])]
+            if "weather_effect" in node_data
+            else [("Status", "Modifierare är inte implementerade ännu.")]
+        )
+        self._add_overview_section(parent, "Modifierare", modifier_rows)
+        self._add_overview_section(
+            parent,
+            "Resultat & logg",
+            (
+                (
+                    "Status",
+                    "Resultat- och förvaltningslogg är inte implementerad ännu.",
+                ),
+            ),
+        )
+
     def show_node_view(self, node_data):
         self.app.commit_pending_changes()
         self.clear()
@@ -519,23 +614,21 @@ class NodeDetailsView:
         scroll_frame.pack(fill="both", expand=True)
         editor_content_frame = scroll_frame.content
         presentation_scroll = None
-        if 0 <= depth <= 3:
+        if depth >= 0:
             presentation_scroll = self.create_details_scrollable_frame(presentation_tab)
             presentation_scroll.pack(fill="both", expand=True)
             if depth <= 2:
                 self._show_vassals_overview(
                     presentation_scroll.content, node_data, depth, display_name
                 )
-            else:
+            elif depth == 3:
                 self._show_domain_overview(
                     presentation_scroll.content, node_data, depth, display_name
                 )
-        else:
-            ttk.Label(
-                presentation_tab,
-                text=self._PRESENTATION_PLACEHOLDER,
-                padding=10,
-            ).pack(anchor="nw")
+            else:
+                self._show_management_overview(
+                    presentation_scroll.content, node_data, depth, display_name
+                )
 
         def update_scroll_target(_event=None):
             selected_tab = notebook.select()

--- a/tests/ui/test_node_details_notebook.py
+++ b/tests/ui/test_node_details_notebook.py
@@ -170,6 +170,84 @@ def test_domain_overview_handles_missing_optional_values(root, monkeypatch):
     assert "Saknas ännu" in _descendant_texts(presentation_frame)
 
 
+def test_management_overview_contains_read_only_sections(root, monkeypatch):
+    app = ui_app.create_app(root)
+    app.world_data = _build_world()
+    app.world_manager.set_world_data(app.world_data)
+    monkeypatch.setattr(app, "_show_resource_editor", lambda parent, node, depth: None)
+
+    app.show_node_view(app.world_data["nodes"]["5"])
+
+    notebook = _find_notebook(app.details_panel.body)
+    presentation_frame = notebook.nametowidget(notebook.tabs()[1])
+    texts = _descendant_texts(presentation_frame)
+    assert {
+        "Sammanfattning",
+        "Förvaltare",
+        "Assistenter",
+        "Ansvarsområde",
+        "Resurser & lager",
+        "Arbete/DV",
+        "Inkomstutmaning",
+        "Kostnader",
+        "Modifierare",
+        "Resultat & logg",
+    }.issubset(texts)
+    assert not _descendants_of_type(
+        presentation_frame,
+        (tk.Entry, tk.Text, ttk.Button, ttk.Entry, ttk.Combobox, ttk.Spinbox),
+    )
+
+
+def test_management_overview_uses_existing_values_and_safe_fallbacks(root, monkeypatch):
+    app = ui_app.create_app(root)
+    app.world_data = _build_world()
+    node_data = app.world_data["nodes"]["5"]
+    node_data.update(
+        {
+            "res_type": "Lager",
+            "population": 12,
+            "storage_basic": 34,
+            "weather_effect": -2,
+        }
+    )
+    app.world_manager.set_world_data(app.world_data)
+    monkeypatch.setattr(app, "_show_resource_editor", lambda parent, node, depth: None)
+
+    app.show_node_view(node_data)
+
+    notebook = _find_notebook(app.details_panel.body)
+    presentation_frame = notebook.nametowidget(notebook.tabs()[1])
+    texts = _descendant_texts(presentation_frame)
+    assert {"Lager", "12", "34", "-2"}.issubset(texts)
+    assert {
+        "Förvaltarmodell är inte implementerad ännu.",
+        "Assistenter är inte implementerade ännu.",
+        "DV-sammanfattning saknar säker datakälla för denna nod.",
+        "Inkomstutmaningar är inte implementerade ännu.",
+        "Förvaltningskostnader är inte implementerade ännu.",
+        "Resultat- och förvaltningslogg är inte implementerad ännu.",
+    }.issubset(texts)
+
+
+@pytest.mark.parametrize("node_id", [1, 2, 3, 4])
+def test_management_overview_is_not_shown_below_depth_four(root, monkeypatch, node_id):
+    app = ui_app.create_app(root)
+    app.world_data = _build_world()
+    app.world_manager.set_world_data(app.world_data)
+    monkeypatch.setattr(
+        app, "_show_upper_level_node_editor", lambda parent, node, depth: None
+    )
+    monkeypatch.setattr(app, "_show_jarldome_editor", lambda parent, node: None)
+
+    app.show_node_view(app.world_data["nodes"][str(node_id)])
+
+    notebook = _find_notebook(app.details_panel.body)
+    assert "Förvaltning" not in [
+        notebook.tab(tab_id, "text") for tab_id in notebook.tabs()
+    ]
+
+
 @pytest.mark.parametrize("node_id", [1, 2, 3])
 def test_vassals_overview_contains_read_only_sections(root, monkeypatch, node_id):
     app = ui_app.create_app(root)


### PR DESCRIPTION
### Motivation

- Ge en första read-only-implementation av fliken "Förvaltning" för noder på djup 4+ som endast presenterar redan existerande data utan att införa ny domänlogik. 
- Återanvända befintligt presentationsmönster (scrollbar, notebook, rubriker) så att notebook, scrollning och den befintliga editorn i "Redigering" inte påverkas. 

### Description

- Lagt till en ny presentationsfunktion `NodeDetailsView._show_management_overview` som bygger flikens tio sektioner (Sammanfattning, Förvaltare, Assistenter, Ansvarsområde, Resurser & lager, Arbete/DV, Inkomstutmaning, Kostnader, Modifierare, Resultat & logg) och endast läser befintliga nodefält när de finns. 
- Kopplat in funktionen i `NodeDetailsView.show_node_view` så att presentationstabben för djup >= 4 renderar den nya read-only-vyn och att editorn fortfarande laddas under fliken "Redigering". 
- Visar säkra fält direkt (t.ex. `res_type`, `population`, `storage_*`, `weather_effect`) och använder explicita fallbacktexter när ingen säker källa finns (t.ex. "Förvaltarmodell är inte implementerad ännu."). 
- Anpassade tester lades till i `tests/ui/test_node_details_notebook.py` som verifierar rubriker, read-only-egenskaper, fallback-meddelanden och att fliken inte visas för djup < 4; ändrade filer: `src/ui/views/node_details_view.py`, `tests/ui/test_node_details_notebook.py`. 
- Bekräftar att ingen domänlogik, `world_manager`, JSON/schema, skatt eller ägarmodell ändrades i denna PR. 

### Testing

- Formatering: körde `black` på berörda filer och inga formateringsfel kvarstod efter körning. 
- Fokustester: körde `pytest tests/ui/test_node_details_notebook.py` med resultatet 6 passed, 18 skipped (Tk-display saknades och UI-tester skippar i headless-miljö). 
- Full testsvit: körde `pytest -q` med resultatet 237 passed, 80 skipped och 1 befintlig varning, samt total testtäckning rapporterad av testkörningen. 
- Inga befintliga tester ändrades eller försvagades och de nya UI-testerna täcker visning, fallback och depth-gränser; headless-skippade Tk-tester rapporterades som förväntat.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eff9612d4832ea5f7ba032f176e64)