### PR TITLE
Add minimal local population rollup policy

### DIFF
--- a/src/rollup_policy.py
+++ b/src/rollup_policy.py
@@ -1,0 +1,37 @@
+"""Domain policy for values contributed to recursive rollups."""
+
+from typing import Any, Mapping
+
+POPULATION_CATEGORIES = (
+    "free_peasants",
+    "unfree_peasants",
+    "thralls",
+    "burghers",
+)
+
+
+def _non_negative_int(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def get_local_population_contribution(node: Mapping[str, Any]) -> int:
+    """Return only population originating on this node."""
+    if any(category in node for category in POPULATION_CATEGORIES):
+        return sum(
+            _non_negative_int(node.get(category)) for category in POPULATION_CATEGORIES
+        )
+
+    if "_base_population" in node:
+        return _non_negative_int(node.get("_base_population"))
+
+    if node.get("children"):
+        return 0
+
+    level = node.get("level", node.get("depth"))
+    if level is not None and _non_negative_int(level) <= 3:
+        return 0
+
+    return _non_negative_int(node.get("population"))

--- a/src/world_manager.py
+++ b/src/world_manager.py
@@ -23,6 +23,7 @@ from personal_province import (
     build_personal_path,
     validate_assignment,
 )
+from rollup_policy import get_local_population_contribution
 from world_interface import WorldInterface
 
 
@@ -603,27 +604,7 @@ class WorldManager(WorldInterface):
             "buildings": {},
         }
 
-        # Node's own population (ignoring aggregated child totals)
-        try:
-            pop = (
-                int(node.get("free_peasants", 0) or 0)
-                + int(node.get("unfree_peasants", 0) or 0)
-                + int(node.get("thralls", 0) or 0)
-                + int(node.get("burghers", 0) or 0)
-            )
-        except (ValueError, TypeError):
-            pop = 0
-        if not pop:
-            base = node.get("_base_population")
-            try:
-                pop = (
-                    int(base)
-                    if base is not None
-                    else int(node.get("population", 0) or 0)
-                )
-            except (ValueError, TypeError):
-                pop = 0
-        totals["population"] += pop
+        totals["population"] += get_local_population_contribution(node)
 
         for entry in node.get("soldiers", []):
             t = entry.get("type")

--- a/tests/test_rollup_policy.py
+++ b/tests/test_rollup_policy.py
@@ -1,0 +1,51 @@
+import copy
+
+from src.rollup_policy import get_local_population_contribution
+
+
+def test_local_population_contribution_uses_population_categories():
+    node = {"free_peasants": 6}
+
+    assert get_local_population_contribution(node) == 6
+
+
+def test_summary_node_population_is_not_a_local_contribution():
+    node = {"res_type": "Gods", "population": 6, "children": [2]}
+
+    assert get_local_population_contribution(node) == 0
+
+
+def test_local_population_contribution_uses_base_population_fallback():
+    node = {"_base_population": 4}
+
+    assert get_local_population_contribution(node) == 4
+
+
+def test_local_population_contribution_does_not_mutate_node():
+    node = {"free_peasants": 6, "children": [2]}
+    original = copy.deepcopy(node)
+
+    get_local_population_contribution(node)
+
+    assert node == original
+
+
+def test_local_population_contribution_handles_missing_values():
+    assert get_local_population_contribution({}) == 0
+
+
+def test_local_population_contribution_handles_invalid_values_safely():
+    node = {
+        "free_peasants": "invalid",
+        "unfree_peasants": -2,
+        "thralls": None,
+        "burghers": 3,
+    }
+
+    assert get_local_population_contribution(node) == 3
+
+
+def test_low_level_reported_population_is_not_a_local_contribution():
+    node = {"level": 3, "population": 6}
+
+    assert get_local_population_contribution(node) == 0

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -181,9 +181,9 @@ def test_calculate_total_resources_recursive():
     manager = WorldManager(world)
     totals = manager.calculate_total_resources(1)
 
-    assert totals["population"] == 14
+    assert totals["population"] == 9
     assert totals["soldiers"]["Archer"] == 3
-    assert world["nodes"]["2"]["total_resources"]["population"] == 7
+    assert world["nodes"]["2"]["total_resources"]["population"] == 2
     assert world["nodes"]["4"]["total_resources"]["population"] == 2
 
 
@@ -195,7 +195,7 @@ def test_calculate_total_resources_cycle():
                 "node_id": 2,
                 "parent_id": 1,
                 "children": [1],  # cycle back to root
-                "population": 5,
+                "_base_population": 5,
             },
         },
         "characters": {},
@@ -235,6 +235,73 @@ def test_total_resources_uses_base_population():
     assert totals["population"] == 6
     assert world["nodes"]["1"]["total_resources"]["population"] == 6
     assert world["nodes"]["4"]["total_resources"]["population"] == 6
+
+
+def _population_world(direct_population=None, estate_population=None):
+    nodes = {
+        "1": {"node_id": 1, "parent_id": None, "children": []},
+    }
+    if direct_population is not None:
+        nodes["2"] = {
+            "node_id": 2,
+            "parent_id": 1,
+            "children": [],
+            "res_type": "Bosättning",
+            "free_peasants": direct_population,
+        }
+        nodes["1"]["children"].append(2)
+    if estate_population is not None:
+        nodes["3"] = {
+            "node_id": 3,
+            "parent_id": 1,
+            "children": [4],
+            "res_type": "Gods",
+            "population": estate_population,
+        }
+        nodes["4"] = {
+            "node_id": 4,
+            "parent_id": 3,
+            "children": [],
+            "res_type": "Bosättning",
+            "free_peasants": 6,
+        }
+        nodes["1"]["children"].append(3)
+    return {"nodes": nodes, "characters": {}}
+
+
+def test_population_rollup_counts_direct_village_once():
+    manager = WorldManager(_population_world(direct_population=6))
+
+    assert manager.calculate_total_resources(1)["population"] == 6
+
+
+def test_population_rollup_counts_village_under_estate_once():
+    manager = WorldManager(_population_world(estate_population=0))
+
+    assert manager.calculate_total_resources(1)["population"] == 6
+
+
+def test_population_rollup_ignores_estate_report_value():
+    manager = WorldManager(_population_world(estate_population=6))
+
+    assert manager.calculate_total_resources(1)["population"] == 6
+
+
+def test_population_rollup_counts_each_source_node_once():
+    manager = WorldManager(
+        _population_world(direct_population=4, estate_population=6)
+    )
+
+    assert manager.calculate_total_resources(1)["population"] == 10
+
+
+def test_population_rollup_counts_node_reached_by_both_links_once():
+    world = _population_world(direct_population=6)
+    world["nodes"]["1"]["children"] = []
+
+    manager = WorldManager(world)
+
+    assert manager.calculate_total_resources(1)["population"] == 6
 
 
 def test_count_descendants_simple_hierarchy():


### PR DESCRIPTION
### Motivation
- Introduce a small central helper to decide how much of a node's population should be treated as a local contribution to recursive rollups, to avoid double-counting when parent nodes contain child settlements. 
- Keep the change narrowly scoped to population only and avoid touching schema, UI, tax, ownership, or global rollup engines. 
- Make the policy easy to extend later and ensure WorldManager uses it in a minimal, well-contained way.

### Description
- Add `src/rollup_policy.py` with `get_local_population_contribution(node)` that sums known population categories, falls back to `_base_population`, treats invalid/negative values as `0`, does not traverse or mutate the node, and suppresses raw `population` for container/low-level nodes. 
- Integrate the helper only into the local population computation inside `WorldManager.calculate_total_resources()` by replacing the previous inline local-population extraction with a call to `get_local_population_contribution(node)`. 
- Add unit tests in `tests/test_rollup_policy.py` covering categories, `_base_population` fallback, missing/invalid values and mutation safety. 
- Add focused integration tests in `tests/test_world_manager.py` asserting villages under estates and direct villages are each counted once, estate `population` reports are ignored as local contributions, and nodes reachable via multiple links are not double-counted, and adjust one existing recursive test expectation to reflect the new policy.

### Testing
- Ran unit tests for the new helper: `python -m pytest -q tests/test_rollup_policy.py` (7 passed). 
- Ran the focused WorldManager tests: `python -m pytest -q --no-cov tests/test_world_manager.py -k 'population_rollup or calculate_total_resources or total_resources_uses_base_population'` (8 passed, 17 deselected). 
- Ran full test suite: `python -m pytest -q` (249 passed, 80 skipped) and repository coverage reported 89.05%, meeting coverage requirements. 
- Static checks: `python -m py_compile src/rollup_policy.py src/world_manager.py` and `git diff --check` passed, and `black` was run on the new helper and its test to satisfy formatting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f06e724e4832e9cd52edf289252b7)