### PR TITLE
Fix work-needed rollup double counting

### DIFF
--- a/src/rollup_policy.py
+++ b/src/rollup_policy.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Mapping
 
+from constants import THRALL_WORK_DAYS
+
 POPULATION_CATEGORIES = (
     "free_peasants",
     "unfree_peasants",
@@ -35,3 +37,25 @@ def get_local_population_contribution(node: Mapping[str, Any]) -> int:
         return 0
 
     return _non_negative_int(node.get("population"))
+
+
+def get_local_work_needed_contribution(
+    node: Mapping[str, Any], *, depth: int | None = None
+) -> int:
+    """Return only work need originating on this node."""
+    if node.get("res_type") in {"Hav", "Flod"}:
+        return _non_negative_int(node.get("fishing_boats")) * THRALL_WORK_DAYS
+
+    node_depth = depth
+    if node_depth is None:
+        node_depth = node.get("level", node.get("depth"))
+
+    try:
+        resolved_depth = int(node_depth)
+    except (TypeError, ValueError):
+        return 0
+
+    if resolved_depth <= 3:
+        return 0
+
+    return _non_negative_int(node.get("work_needed"))

--- a/src/world_manager.py
+++ b/src/world_manager.py
@@ -23,7 +23,10 @@ from personal_province import (
     build_personal_path,
     validate_assignment,
 )
-from rollup_policy import get_local_population_contribution
+from rollup_policy import (
+    get_local_population_contribution,
+    get_local_work_needed_contribution,
+)
 from world_interface import WorldInterface
 
 
@@ -58,7 +61,9 @@ class WorldManager(WorldInterface):
     def set_event_bus(self, event_bus) -> None:
         self._event_bus = event_bus
 
-    def create_snapshot(self, reason: str = "", context: Dict[str, Any] | None = None) -> None:
+    def create_snapshot(
+        self, reason: str = "", context: Dict[str, Any] | None = None
+    ) -> None:
         """Store a lightweight copy of the world for undo/inspection."""
 
         snapshot = {
@@ -130,7 +135,9 @@ class WorldManager(WorldInterface):
             )
 
     def assign_personal_owner(
-        self, province_id: int | str, owner_anchor_id: Tuple[str, int | None] | str | None
+        self,
+        province_id: int | str,
+        owner_anchor_id: Tuple[str, int | None] | str | None,
     ) -> AssignResult:
         """Validate and assign a personal owner for ``province_id``.
 
@@ -402,10 +409,8 @@ class WorldManager(WorldInterface):
     ) -> int:
         """Sum required work days for ``node_id`` and its descendants.
 
-        For water resources (``Hav`` or ``Flod``), the required work is
-        determined by the number of fishing boats. Each boat requires
-        ``THRALL_WORK_DAYS`` work days. For all other resources, the value is
-        read directly from the node's ``work_needed`` field.
+        Local work is determined by the rollup policy before descendant needs
+        are added recursively.
         """
 
         nodes = self.world_data.get("nodes", {})
@@ -418,18 +423,8 @@ class WorldManager(WorldInterface):
         if not node:
             return 0
 
-        res_type = node.get("res_type")
-        if res_type in {"Hav", "Flod"}:
-            try:
-                boats = int(node.get("fishing_boats", 0) or 0)
-            except (ValueError, TypeError):
-                boats = 0
-            total = boats * THRALL_WORK_DAYS
-        else:
-            try:
-                total = int(node.get("work_needed", 0) or 0)
-            except (ValueError, TypeError):
-                total = 0
+        depth = self.get_depth_of_node(node_id)
+        total = get_local_work_needed_contribution(node, depth=depth)
 
         for child in node.get("children", []):
             try:

--- a/tests/test_rollup_policy.py
+++ b/tests/test_rollup_policy.py
@@ -1,6 +1,10 @@
 import copy
 
-from src.rollup_policy import get_local_population_contribution
+from src.constants import THRALL_WORK_DAYS
+from src.rollup_policy import (
+    get_local_population_contribution,
+    get_local_work_needed_contribution,
+)
 
 
 def test_local_population_contribution_uses_population_categories():
@@ -49,3 +53,49 @@ def test_low_level_reported_population_is_not_a_local_contribution():
     node = {"level": 3, "population": 6}
 
     assert get_local_population_contribution(node) == 0
+
+
+def test_local_work_needed_contribution_uses_resource_need():
+    assert get_local_work_needed_contribution({"work_needed": 25}, depth=4) == 25
+
+
+def test_local_work_needed_contribution_ignores_level_three_report_total():
+    assert get_local_work_needed_contribution({"work_needed": 100}, depth=3) == 0
+
+
+def test_local_work_needed_contribution_uses_fishing_boats_for_water():
+    for res_type in ("Hav", "Flod"):
+        node = {
+            "res_type": res_type,
+            "fishing_boats": 2,
+            "work_needed": 999,
+        }
+
+        assert get_local_work_needed_contribution(node, depth=4) == 2 * THRALL_WORK_DAYS
+
+
+def test_local_work_needed_contribution_does_not_mutate_node():
+    node = {"work_needed": 25, "children": [2]}
+    original = copy.deepcopy(node)
+
+    get_local_work_needed_contribution(node, depth=4)
+
+    assert node == original
+
+
+def test_local_work_needed_contribution_handles_invalid_values_safely():
+    assert get_local_work_needed_contribution({}, depth=4) == 0
+    assert get_local_work_needed_contribution({"work_needed": "invalid"}, depth=4) == 0
+    assert get_local_work_needed_contribution({"work_needed": -25}, depth=4) == 0
+    assert (
+        get_local_work_needed_contribution(
+            {"res_type": "Hav", "fishing_boats": -2}, depth=4
+        )
+        == 0
+    )
+
+
+def test_local_work_needed_contribution_uses_node_depth_fallback():
+    assert get_local_work_needed_contribution({"depth": 4, "work_needed": 25}) == 25
+    assert get_local_work_needed_contribution({"level": 3, "work_needed": 25}) == 0
+    assert get_local_work_needed_contribution({"work_needed": 25}) == 0

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -288,9 +288,7 @@ def test_population_rollup_ignores_estate_report_value():
 
 
 def test_population_rollup_counts_each_source_node_once():
-    manager = WorldManager(
-        _population_world(direct_population=4, estate_population=6)
-    )
+    manager = WorldManager(_population_world(direct_population=4, estate_population=6))
 
     assert manager.calculate_total_resources(1)["population"] == 10
 
@@ -658,7 +656,74 @@ def test_calculate_work_needed_counts_fishing_boats():
 
     manager = WorldManager(world)
     total = manager.calculate_work_needed(1)
-    assert total == 50 + 3 * THRALL_WORK_DAYS
+    assert total == 3 * THRALL_WORK_DAYS
+
+
+def _work_needed_world(jarldom_work=0, child_needs=(10,)):
+    nodes = {
+        "1": {"node_id": 1, "parent_id": None, "children": [2]},
+        "2": {"node_id": 2, "parent_id": 1, "children": [3]},
+        "3": {"node_id": 3, "parent_id": 2, "children": [4]},
+        "4": {
+            "node_id": 4,
+            "parent_id": 3,
+            "children": list(range(5, 5 + len(child_needs))),
+            "work_needed": jarldom_work,
+        },
+    }
+    for node_id, work_needed in enumerate(child_needs, start=5):
+        nodes[str(node_id)] = {
+            "node_id": node_id,
+            "parent_id": 4,
+            "children": [],
+            "work_needed": work_needed,
+        }
+    return {"nodes": nodes, "characters": {}}
+
+
+def test_update_work_needed_does_not_recount_stored_jarldom_total():
+    world = _work_needed_world(child_needs=(10,))
+    manager = WorldManager(world)
+
+    assert manager.update_work_needed(4) == 10
+    assert manager.update_work_needed(4) == 10
+    assert world["nodes"]["4"]["work_needed"] == 10
+
+
+def test_calculate_work_needed_ignores_stored_jarldom_report_total():
+    manager = WorldManager(_work_needed_world(jarldom_work=100, child_needs=(10,)))
+
+    assert manager.calculate_work_needed(4) == 10
+
+
+def test_calculate_work_needed_sums_each_local_resource_once():
+    manager = WorldManager(_work_needed_world(child_needs=(10, 20)))
+
+    assert manager.calculate_work_needed(4) == 30
+
+
+def test_calculate_work_needed_keeps_water_fishing_boat_need():
+    world = _work_needed_world(child_needs=(999,))
+    world["nodes"]["5"].update({"res_type": "Flod", "fishing_boats": 2})
+    manager = WorldManager(world)
+
+    assert manager.calculate_work_needed(4) == 2 * THRALL_WORK_DAYS
+
+
+def test_calculate_work_needed_counts_duplicate_child_reference_once():
+    world = _work_needed_world(child_needs=(10,))
+    world["nodes"]["4"]["children"] = [5, 5]
+    manager = WorldManager(world)
+
+    assert manager.calculate_work_needed(4) == 10
+
+
+def test_calculate_work_needed_stops_at_cycles():
+    world = _work_needed_world(child_needs=(10,))
+    world["nodes"]["5"]["children"] = [4]
+    manager = WorldManager(world)
+
+    assert manager.calculate_work_needed(4) == 10
 
 
 def test_calculate_license_income_sums_descendants():


### PR DESCRIPTION
### Motivation
- `calculate_work_needed()` treated a node's stored `work_needed` as a local source and then added children, and `update_work_needed()` wrote the rolled-up total back into the same field, which allowed totals on level-3 (jarldom) nodes to be re-read as local need and double-counted on subsequent runs.
- Introduce a minimal, local policy so reported totals (level 0–3) are not treated as originating local needs while preserving legitimate local needs on level 4+ and water/fishing semantics.

### Description
- Added `get_local_work_needed_contribution(node, *, depth=None)` in `src/rollup_policy.py` which:
  - Returns `fishing_boats * THRALL_WORK_DAYS` for `res_type` of `Hav` or `Flod` and ignores any saved `work_needed` on those nodes.
  - Uses `depth` (or node `level`/`depth` fallback) and returns `0` for resolved depths `<= 3` to treat those `work_needed` values as reported totals.
  - Returns a normalized non-negative integer for `work_needed` on depth `>= 4` and safely treats missing/invalid/negative inputs as `0`.
  - Is pure, non-mutating and does not traverse the tree.
- Integrated the helper in `WorldManager.calculate_work_needed()` (in `src/world_manager.py`) by calling `get_depth_of_node(node_id)` and using `get_local_work_needed_contribution(...)` for the node-local portion, then summing children recursively as before; `visited` cycle protection and recursion strategy remained unchanged.
- Did not change `update_work_needed()` semantics (it still writes the rolled-up total to the node), but the policy ensures repeated `update_work_needed()` calls are idempotent for the tested scenarios because level-3 `work_needed` is no longer counted as local source.
- Files changed: `src/rollup_policy.py`, `src/world_manager.py`, `tests/test_rollup_policy.py`, `tests/test_world_manager.py`.
- Tests added (focused): `test_local_work_needed_contribution_uses_resource_need`, `test_local_work_needed_contribution_ignores_level_three_report_total`, `test_local_work_needed_contribution_uses_fishing_boats_for_water`, `test_local_work_needed_contribution_does_not_mutate_node`, `test_local_work_needed_contribution_handles_invalid_values_safely`, `test_local_work_needed_contribution_uses_node_depth_fallback`, `test_update_work_needed_does_not_recount_stored_jarldom_total`, `test_calculate_work_needed_ignores_stored_jarldom_report_total`, `test_calculate_work_needed_sums_each_local_resource_once`, `test_calculate_work_needed_keeps_water_fishing_boat_need`, `test_calculate_work_needed_counts_duplicate_child_reference_once`, `test_calculate_work_needed_stops_at_cycles`.

### Testing
- Ran focused policy tests: `python -m pytest -q tests/test_rollup_policy.py --no-cov` — all policy tests passed.
- Ran focused integration tests: `python -m pytest -q tests/test_world_manager.py -k 'work_needed' --no-cov` — all selected work-needed tests passed.
- Ran full test-suite: `python -m pytest -q` — `261 passed, 80 skipped` and coverage reached ~89% (required 30%).
- Static checks: `python -m py_compile src/rollup_policy.py src/world_manager.py` passed and `black` formatting check passed after formatting.
- `git diff --check` produced no issues.
- Confirmations: `update_work_needed()` is idempotent for the provided regression fixture (jarldom with a single child needing 10 returns and persists `10`), water nodes still use `fishing_boats`, `calculate_work_available()` and UI/schema/server logic were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f0f9199dc832ea44c3a4469a5b81a)