### PR TITLE
Phase A: add get_local_work_available_contribution helper and tests

### DIFF
--- a/src/rollup_policy.py
+++ b/src/rollup_policy.py
@@ -2,7 +2,11 @@
 
 from typing import Any, Mapping
 
-from constants import THRALL_WORK_DAYS
+from constants import (
+    DAGSVERKEN_MULTIPLIERS,
+    DAY_LABORER_WORK_DAYS,
+    THRALL_WORK_DAYS,
+)
 
 POPULATION_CATEGORIES = (
     "free_peasants",
@@ -59,3 +63,21 @@ def get_local_work_needed_contribution(
         return 0
 
     return _non_negative_int(node.get("work_needed"))
+
+
+def get_local_work_available_contribution(
+    node: Mapping[str, Any],
+    *,
+    depth: int | None = None,
+) -> int:
+    """Return work capacity explicitly originating on this node."""
+    del depth
+    dagsverken = node.get("dagsverken", "normalt")
+    multiplier = DAGSVERKEN_MULTIPLIERS.get(
+        dagsverken, DAGSVERKEN_MULTIPLIERS["normalt"]
+    )
+    return (
+        _non_negative_int(node.get("thralls")) * THRALL_WORK_DAYS
+        + _non_negative_int(node.get("unfree_peasants")) * multiplier
+        + _non_negative_int(node.get("day_laborers_hired")) * DAY_LABORER_WORK_DAYS
+    )

--- a/tests/test_rollup_policy.py
+++ b/tests/test_rollup_policy.py
@@ -1,8 +1,13 @@
 import copy
 
-from src.constants import THRALL_WORK_DAYS
+from src.constants import (
+    DAGSVERKEN_MULTIPLIERS,
+    DAY_LABORER_WORK_DAYS,
+    THRALL_WORK_DAYS,
+)
 from src.rollup_policy import (
     get_local_population_contribution,
+    get_local_work_available_contribution,
     get_local_work_needed_contribution,
 )
 
@@ -99,3 +104,101 @@ def test_local_work_needed_contribution_uses_node_depth_fallback():
     assert get_local_work_needed_contribution({"depth": 4, "work_needed": 25}) == 25
     assert get_local_work_needed_contribution({"level": 3, "work_needed": 25}) == 0
     assert get_local_work_needed_contribution({"work_needed": 25}) == 0
+
+
+def test_local_work_available_contribution_counts_thralls():
+    assert get_local_work_available_contribution({"thralls": 2}) == 2 * THRALL_WORK_DAYS
+
+
+def test_local_work_available_contribution_counts_unfree_peasants():
+    node = {"unfree_peasants": 3, "dagsverken": "många"}
+
+    assert (
+        get_local_work_available_contribution(node)
+        == 3 * DAGSVERKEN_MULTIPLIERS["många"]
+    )
+
+
+def test_local_work_available_contribution_counts_hired_day_laborers():
+    assert (
+        get_local_work_available_contribution({"day_laborers_hired": 4})
+        == 4 * DAY_LABORER_WORK_DAYS
+    )
+
+
+def test_local_work_available_contribution_ignores_available_day_laborers():
+    assert get_local_work_available_contribution({"day_laborers_available": 4}) == 0
+
+
+def test_local_work_available_contribution_ignores_stored_report_total():
+    assert get_local_work_available_contribution({"work_available": 999}) == 0
+
+
+def test_local_work_available_contribution_ignores_work_needed():
+    assert get_local_work_available_contribution({"work_needed": 999}) == 0
+
+
+def test_local_work_available_contribution_handles_invalid_values():
+    node = {
+        "thralls": "invalid",
+        "unfree_peasants": object(),
+        "day_laborers_hired": "invalid",
+    }
+
+    assert get_local_work_available_contribution(node) == 0
+
+
+def test_local_work_available_contribution_clamps_negative_values():
+    node = {
+        "thralls": -1,
+        "unfree_peasants": -2,
+        "day_laborers_hired": -3,
+    }
+
+    assert get_local_work_available_contribution(node) == 0
+
+
+def test_local_work_available_contribution_uses_normal_for_missing_dagsverken():
+    assert (
+        get_local_work_available_contribution({"unfree_peasants": 2})
+        == 2 * DAGSVERKEN_MULTIPLIERS["normalt"]
+    )
+
+
+def test_local_work_available_contribution_uses_normal_for_invalid_dagsverken():
+    node = {"unfree_peasants": 2, "dagsverken": "invalid"}
+
+    assert (
+        get_local_work_available_contribution(node)
+        == 2 * DAGSVERKEN_MULTIPLIERS["normalt"]
+    )
+
+
+def test_local_work_available_contribution_does_not_mutate_node():
+    node = {"thralls": 2, "children": [3]}
+    original = copy.deepcopy(node)
+
+    get_local_work_available_contribution(node)
+
+    assert node == original
+
+
+def test_local_work_available_contribution_keeps_explicit_local_people_with_children():
+    node = {"thralls": 2, "children": [3]}
+
+    assert get_local_work_available_contribution(node) == 2 * THRALL_WORK_DAYS
+
+
+def test_local_work_available_contribution_does_not_assume_depth_three_is_report_only():
+    assert (
+        get_local_work_available_contribution({"thralls": 2}, depth=3)
+        == 2 * THRALL_WORK_DAYS
+    )
+
+
+def test_local_work_available_contribution_accepts_depth_without_changing_current_behavior():
+    node = {"thralls": 1, "unfree_peasants": 2}
+
+    assert get_local_work_available_contribution(
+        node, depth=0
+    ) == get_local_work_available_contribution(node)

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -560,6 +560,159 @@ def test_calculate_work_available_includes_day_laborers():
     assert total == DAY_LABORER_WORK_DAYS * 2
 
 
+def test_calculate_work_available_ignores_stored_work_available():
+    world = {
+        "nodes": {
+            "1": {
+                "node_id": 1,
+                "parent_id": None,
+                "children": [],
+                "work_available": 999,
+            }
+        },
+        "characters": {},
+    }
+
+    assert WorldManager(world).calculate_work_available(1) == 0
+
+
+def test_calculate_work_available_counts_duplicate_child_reference_once():
+    world = {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None, "children": [2, 2]},
+            "2": {
+                "node_id": 2,
+                "parent_id": 1,
+                "children": [],
+                "thralls": 1,
+            },
+        },
+        "characters": {},
+    }
+
+    assert WorldManager(world).calculate_work_available(1) == THRALL_WORK_DAYS
+
+
+def test_calculate_work_available_stops_at_cycles():
+    world = {
+        "nodes": {
+            "1": {
+                "node_id": 1,
+                "parent_id": None,
+                "children": [2],
+                "thralls": 1,
+            },
+            "2": {
+                "node_id": 2,
+                "parent_id": 1,
+                "children": [1],
+                "thralls": 1,
+            },
+        },
+        "characters": {},
+    }
+
+    assert WorldManager(world).calculate_work_available(1) == 2 * THRALL_WORK_DAYS
+
+
+def test_calculate_work_available_counts_root_local_people():
+    world = {
+        "nodes": {
+            "1": {
+                "node_id": 1,
+                "parent_id": None,
+                "children": [],
+                "thralls": 1,
+                "unfree_peasants": 2,
+                "dagsverken": "normalt",
+            }
+        },
+        "characters": {},
+    }
+
+    expected = THRALL_WORK_DAYS + 2 * DAGSVERKEN_MULTIPLIERS["normalt"]
+    assert WorldManager(world).calculate_work_available(1) == expected
+
+
+def test_calculate_work_available_treats_same_village_equally_under_estate():
+    direct_world = {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None, "children": [2]},
+            "2": {
+                "node_id": 2,
+                "parent_id": 1,
+                "children": [],
+                "thralls": 1,
+                "unfree_peasants": 2,
+            },
+        },
+        "characters": {},
+    }
+    estate_world = {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None, "children": [2]},
+            "2": {
+                "node_id": 2,
+                "parent_id": 1,
+                "children": [3],
+                "res_type": "Gods",
+            },
+            "3": {
+                "node_id": 3,
+                "parent_id": 2,
+                "children": [],
+                "thralls": 1,
+                "unfree_peasants": 2,
+            },
+        },
+        "characters": {},
+    }
+
+    direct_total = WorldManager(direct_world).calculate_work_available(1)
+    estate_total = WorldManager(estate_world).calculate_work_available(1)
+
+    assert estate_total == direct_total
+
+
+def test_calculate_work_available_ignores_available_day_laborers():
+    world = {
+        "nodes": {
+            "1": {
+                "node_id": 1,
+                "parent_id": None,
+                "children": [],
+                "day_laborers_available": 10,
+            }
+        },
+        "characters": {},
+    }
+
+    assert WorldManager(world).calculate_work_available(1) == 0
+
+
+def test_calculate_work_available_documents_duplicate_person_model_risk():
+    world = {
+        "nodes": {
+            "1": {
+                "node_id": 1,
+                "parent_id": None,
+                "children": [2],
+                "thralls": 1,
+            },
+            "2": {
+                "node_id": 2,
+                "parent_id": 1,
+                "children": [],
+                "thralls": 1,
+            },
+        },
+        "characters": {},
+    }
+
+    # Current traversal counts both explicit values; their provenance is unresolved.
+    assert WorldManager(world).calculate_work_available(1) == 2 * THRALL_WORK_DAYS
+
+
 def test_calculate_umbarande_excludes_other_jarldoms():
     world = {
         "nodes": {


### PR DESCRIPTION
### Motivation
- Provide a small, pure domain helper that computes a node's explicit local DV/work-available contribution without changing existing traversal or production code.
- Keep the helper narrowly scoped to local fields to avoid making provenance/container rules before the model is decided.
- Protect current `WorldManager.calculate_work_available()` behavior with regression tests so future integration is safe.

### Description
- Added `get_local_work_available_contribution(node, *, depth=None)` in `src/rollup_policy.py` that returns an int and is pure, non-mutating and non-traversing; it reads only `thralls`, `unfree_peasants`, `day_laborers_hired`, and `dagsverken` and ignores `work_available`, `work_needed`, `day_laborers_available`, `children` and `parent_id`.
- The helper uses `_non_negative_int()` and constants to compute `thralls * THRALL_WORK_DAYS + unfree_peasants * DAGSVERKEN_MULTIPLIERS[dagsverken] + day_laborers_hired * DAY_LABORER_WORK_DAYS`, clamps negatives to 0, treats missing/invalid `dagsverken` as `"normalt"`, and accepts `depth` but does not use it in this phase.
- Added focused policy tests in `tests/test_rollup_policy.py` covering thralls, unfree peasants, day laborers hired, ignored fields, invalid/negative inputs, `dagsverken` normalization, non-mutation, children behavior and `depth` symmetry.
- Added regression tests in `tests/test_world_manager.py` that document current `calculate_work_available()` behavior (ignores stored `work_available`, counts duplicate child references once, stops at cycles, counts root local people, treats village under estate equivalently, ignores `day_laborers_available`, and documents the duplicate-person model risk); did not change `WorldManager` or integrate the helper.

### Testing
- Ran focused module tests: `python -m pytest -q tests/test_rollup_policy.py --no-cov` (27 passed) and `python -m pytest -q tests/test_world_manager.py --no-cov` (38 passed).
- Ran full test suite: `python -m pytest -q` which completed with **282 passed, 80 skipped** and coverage satisfied (89.05%); `py_compile` and `black --check` passed for the changed files.
- Diff summary: changed files `src/rollup_policy.py`, `tests/test_rollup_policy.py`, `tests/test_world_manager.py` with a total of 3 files modified and +280/-2 lines; `WorldManager.calculate_work_available()` and all UI/schema/server code were left unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fef372b74832ebcbd9aa1105f105a)