### PR TITLE
Add strict local physical storage policy

### DIFF
--- a/src/rollup_policy.py
+++ b/src/rollup_policy.py
@@ -15,6 +15,20 @@ POPULATION_CATEGORIES = (
     "burghers",
 )
 
+STORAGE_RESOURCE_KEYS = (
+    "storage_basic",
+    "storage_luxury",
+    "storage_silver",
+    "storage_timber",
+    "storage_coal",
+    "storage_iron_ore",
+    "storage_iron",
+    "storage_animal_feed",
+    "storage_skin",
+)
+
+PHYSICAL_STORAGE_NODE_TYPES = frozenset({"Lager"})
+
 
 def _non_negative_int(value: Any) -> int:
     try:
@@ -41,6 +55,21 @@ def get_local_population_contribution(node: Mapping[str, Any]) -> int:
         return 0
 
     return _non_negative_int(node.get("population"))
+
+
+def get_local_storage_contribution(
+    node: Mapping[str, Any],
+    resource_key: str,
+    *,
+    depth: int | None = None,
+) -> int:
+    """Return local physical storage contribution for one storage resource key."""
+    del depth
+    if resource_key not in STORAGE_RESOURCE_KEYS:
+        return 0
+    if node.get("res_type") not in PHYSICAL_STORAGE_NODE_TYPES:
+        return 0
+    return _non_negative_int(node.get(resource_key))
 
 
 def get_local_work_needed_contribution(

--- a/tests/test_rollup_policy.py
+++ b/tests/test_rollup_policy.py
@@ -1,12 +1,17 @@
 import copy
 
+import pytest
+
 from src.constants import (
     DAGSVERKEN_MULTIPLIERS,
     DAY_LABORER_WORK_DAYS,
     THRALL_WORK_DAYS,
 )
 from src.rollup_policy import (
+    PHYSICAL_STORAGE_NODE_TYPES,
+    STORAGE_RESOURCE_KEYS,
     get_local_population_contribution,
+    get_local_storage_contribution,
     get_local_work_available_contribution,
     get_local_work_needed_contribution,
 )
@@ -58,6 +63,113 @@ def test_low_level_reported_population_is_not_a_local_contribution():
     node = {"level": 3, "population": 6}
 
     assert get_local_population_contribution(node) == 0
+
+
+def test_local_storage_contribution_counts_lager_value():
+    node = {"res_type": "Lager", "storage_basic": 7}
+
+    assert get_local_storage_contribution(node, "storage_basic") == 7
+
+
+def test_local_storage_contribution_ignores_jarldom_storage_value():
+    node = {"res_type": "Jarldöme", "storage_basic": 7}
+
+    assert get_local_storage_contribution(node, "storage_basic", depth=3) == 0
+
+
+def test_local_storage_contribution_ignores_estate_storage_value():
+    node = {"res_type": "Gods", "storage_basic": 7}
+
+    assert get_local_storage_contribution(node, "storage_basic") == 0
+
+
+def test_local_storage_contribution_ignores_settlement_storage_value():
+    node = {"res_type": "Bosättning", "storage_basic": 7}
+
+    assert get_local_storage_contribution(node, "storage_basic") == 0
+
+
+def test_local_storage_contribution_ignores_upper_level_storage_value():
+    node = {"res_type": "Rike", "storage_basic": 7}
+
+    assert get_local_storage_contribution(node, "storage_basic", depth=0) == 0
+
+
+@pytest.mark.parametrize("resource_key", STORAGE_RESOURCE_KEYS)
+def test_local_storage_contribution_supports_all_storage_keys(resource_key):
+    node = {"res_type": "Lager", resource_key: 5}
+
+    assert get_local_storage_contribution(node, resource_key) == 5
+
+
+def test_local_storage_contribution_handles_missing_value():
+    assert get_local_storage_contribution({"res_type": "Lager"}, "storage_basic") == 0
+
+
+def test_local_storage_contribution_handles_none_value():
+    node = {"res_type": "Lager", "storage_basic": None}
+
+    assert get_local_storage_contribution(node, "storage_basic") == 0
+
+
+def test_local_storage_contribution_handles_invalid_value():
+    node = {"res_type": "Lager", "storage_basic": "invalid"}
+
+    assert get_local_storage_contribution(node, "storage_basic") == 0
+
+
+def test_local_storage_contribution_accepts_numeric_string():
+    node = {"res_type": "Lager", "storage_basic": "7"}
+
+    assert get_local_storage_contribution(node, "storage_basic") == 7
+
+
+def test_local_storage_contribution_clamps_negative_value():
+    node = {"res_type": "Lager", "storage_basic": -7}
+
+    assert get_local_storage_contribution(node, "storage_basic") == 0
+
+
+def test_local_storage_contribution_ignores_unknown_resource_key():
+    node = {"res_type": "Lager", "storage_unknown": 7}
+
+    assert get_local_storage_contribution(node, "storage_unknown") == 0
+
+
+def test_local_storage_contribution_requires_lager_res_type():
+    assert get_local_storage_contribution({"storage_basic": 7}, "storage_basic") == 0
+
+
+def test_local_storage_contribution_does_not_mutate_node():
+    node = {
+        "res_type": "Lager",
+        "storage_basic": 7,
+        "children": [{"storage_basic": 99}],
+        "parent_id": 1,
+    }
+    original = copy.deepcopy(node)
+
+    get_local_storage_contribution(node, "storage_basic", depth=2)
+
+    assert node == original
+
+
+def test_storage_resource_keys_contains_expected_keys():
+    assert STORAGE_RESOURCE_KEYS == (
+        "storage_basic",
+        "storage_luxury",
+        "storage_silver",
+        "storage_timber",
+        "storage_coal",
+        "storage_iron_ore",
+        "storage_iron",
+        "storage_animal_feed",
+        "storage_skin",
+    )
+
+
+def test_physical_storage_node_types_only_lager():
+    assert PHYSICAL_STORAGE_NODE_TYPES == frozenset({"Lager"})
 
 
 def test_local_work_needed_contribution_uses_resource_need():


### PR DESCRIPTION
### Motivation

- Define a safe, minimal rule for which nodes count as local physical storage sources (only real warehouses), without introducing reporting, aggregation, ownership, transfer, consumption or economy semantics.
- Preserve existing `storage_*` fields on other node types as historical data while excluding them from the first safe storage helper, and keep the implementation clean and testable inside the rollup policy layer.

### Description

- Added `STORAGE_RESOURCE_KEYS` with the nine agreed keys and `PHYSICAL_STORAGE_NODE_TYPES = frozenset({"Lager"})` to `src/rollup_policy.py`.
- Implemented the pure helper `get_local_storage_contribution(node, resource_key, *, depth=None)` in `src/rollup_policy.py`, which validates `resource_key`, requires `node.get("res_type") == "Lager"`, accepts numeric strings, clamps negatives to `0`, treats missing/`None`/invalid values as `0`, does not traverse `children`, does not read `parent_id`, does not mutate `node`, and ignores `depth` for this version.
- Added focused tests in `tests/test_rollup_policy.py` that exercise the positive Lager case, negative cases for non-Lager types (Jarldöme, Gods, Bosättning, upper-level nodes), all nine storage keys (parametrized), missing/None/invalid/negative values, numeric-string handling, unknown key handling, `res_type` absence, and non-mutation checks.
- Only `src/rollup_policy.py` and `tests/test_rollup_policy.py` were changed; no WorldManager, UI, schema, serialization, reporting, or aggregation logic was modified or added.

### Testing

- Ran `python -m pytest -q tests/test_rollup_policy.py` which executed the 51 focused tests and they all passed (note: running only that file initially triggered the repository coverage guard, see next bullet).
- Ran `python -m pytest -q` which produced `314 passed, 80 skipped` and overall coverage `89.05%`, so repository-wide CI constraints are satisfied.
- Ran `python -m py_compile src/rollup_policy.py`, `python -m black --check src/rollup_policy.py tests/test_rollup_policy.py`, and `git diff --check`, all succeeded.

Notes / confirmations

- `get_local_storage_contribution()` returns an `int` and never negative; unknown `resource_key` returns `0`; missing/`None`/non-numeric/negative values return `0`; numeric strings like `"7"` return `7`.
- Only nodes with `res_type == "Lager"` contribute; BAS/LYX/silver on Jarldöme/Gods/Bosättning or other non-Lager nodes are explicitly ignored by the helper.
- All nine storage keys are present in `STORAGE_RESOURCE_KEYS` and covered by tests.
- The `depth` parameter is accepted for API symmetry but deliberately ignored in decision logic in this PR.
- No changes were made to `WorldManager`, UI code, JSON/schema, serialization, reporting functions, storage summation, or any transfer/consumption/tax/economy/annual-loop/project logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3010f05c64832eba7bfdfca66849df)