### PR TITLE
Add read-only physical storage subtree report

### DIFF
--- a/src/world_manager.py
+++ b/src/world_manager.py
@@ -21,7 +21,9 @@ from personal_province import (
     validate_assignment,
 )
 from rollup_policy import (
+    STORAGE_RESOURCE_KEYS,
     get_local_population_contribution,
+    get_local_storage_contribution,
     get_local_work_available_contribution,
     get_local_work_needed_contribution,
 )
@@ -623,6 +625,57 @@ class WorldManager(WorldInterface):
                     add_count(totals[key], res, amt)
 
         node["total_resources"] = copy.deepcopy(totals)
+        return totals
+
+    def get_storage_report(self, node_id) -> dict[str, int]:
+        """Return reported physical storage totals for the rooted subtree."""
+        totals = {resource_key: 0 for resource_key in STORAGE_RESOURCE_KEYS}
+        nodes = self.world_data.get("nodes", {})
+
+        try:
+            root_id = int(node_id)
+        except (TypeError, ValueError):
+            return totals
+
+        parent_lookup: Dict[int, List[int]] = {}
+        for child_id_raw, child_data in nodes.items():
+            try:
+                child_id = int(child_id_raw)
+            except (TypeError, ValueError):
+                continue
+            parent_id = child_data.get("parent_id")
+            try:
+                parent_id = int(parent_id)
+            except (TypeError, ValueError):
+                continue
+            parent_lookup.setdefault(parent_id, []).append(child_id)
+
+        visited: set[int] = set()
+        pending = [root_id]
+        while pending:
+            current_id = pending.pop()
+            if current_id in visited:
+                continue
+            visited.add(current_id)
+
+            node = nodes.get(str(current_id))
+            if not node:
+                continue
+
+            depth = self.get_depth_of_node(current_id)
+            for resource_key in STORAGE_RESOURCE_KEYS:
+                totals[resource_key] += get_local_storage_contribution(
+                    node, resource_key, depth=depth
+                )
+
+            child_ids = list(node.get("children", []))
+            child_ids.extend(parent_lookup.get(current_id, []))
+            for child_id in child_ids:
+                try:
+                    pending.append(int(child_id))
+                except (TypeError, ValueError):
+                    continue
+
         return totals
 
     # -------------------------------------------

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -9,6 +9,169 @@ from src.constants import (
     DAGSVERKEN_UMBARANDE,
     DAY_LABORER_WORK_DAYS,
 )
+from src.rollup_policy import STORAGE_RESOURCE_KEYS
+
+
+def _storage_node(node_id, parent_id=None, children=None, res_type=None, **values):
+    return {
+        "node_id": node_id,
+        "parent_id": parent_id,
+        "children": children or [],
+        "res_type": res_type,
+        **values,
+    }
+
+
+def _storage_manager(*nodes):
+    return WorldManager(
+        {"nodes": {str(node["node_id"]): node for node in nodes}, "characters": {}}
+    )
+
+
+def test_get_storage_report_returns_all_storage_keys():
+    report = _storage_manager().get_storage_report(999)
+
+    assert set(report) == set(STORAGE_RESOURCE_KEYS)
+    assert all(value == 0 for value in report.values())
+
+
+def test_get_storage_report_counts_direct_lager_child():
+    manager = _storage_manager(
+        _storage_node(1, children=[2], res_type="Jarldöme"),
+        _storage_node(2, 1, res_type="Lager", storage_basic=7),
+    )
+
+    assert manager.get_storage_report(1)["storage_basic"] == 7
+
+
+def test_get_storage_report_counts_nested_lager_under_estate():
+    manager = _storage_manager(
+        _storage_node(1, children=[2], res_type="Jarldöme"),
+        _storage_node(2, 1, [3], "Gods"),
+        _storage_node(3, 2, res_type="Lager", storage_basic=7),
+    )
+
+    assert manager.get_storage_report(1)["storage_basic"] == 7
+
+
+def test_get_storage_report_counts_multiple_lager_nodes():
+    manager = _storage_manager(
+        _storage_node(1, children=[2, 3]),
+        _storage_node(2, 1, res_type="Lager", storage_basic=7),
+        _storage_node(3, 1, res_type="Lager", storage_basic=5),
+    )
+
+    assert manager.get_storage_report(1)["storage_basic"] == 12
+
+
+def test_get_storage_report_supports_all_storage_keys():
+    values = {key: index for index, key in enumerate(STORAGE_RESOURCE_KEYS, 1)}
+    manager = _storage_manager(_storage_node(1, res_type="Lager", **values))
+
+    assert manager.get_storage_report(1) == values
+
+
+def test_get_storage_report_ignores_jarldom_storage_fields():
+    manager = _storage_manager(
+        _storage_node(1, children=[2], res_type="Jarldöme", storage_basic=100),
+        _storage_node(2, 1, res_type="Lager", storage_basic=7),
+    )
+
+    assert manager.get_storage_report(1)["storage_basic"] == 7
+
+
+def test_get_storage_report_ignores_estate_storage_fields():
+    manager = _storage_manager(
+        _storage_node(1, children=[2]),
+        _storage_node(2, 1, [3], "Gods", storage_basic=100),
+        _storage_node(3, 2, res_type="Lager", storage_basic=7),
+    )
+
+    assert manager.get_storage_report(1)["storage_basic"] == 7
+
+
+def test_get_storage_report_ignores_settlement_storage_fields():
+    manager = _storage_manager(
+        _storage_node(1, children=[2]),
+        _storage_node(2, 1, [3], "By", storage_basic=100),
+        _storage_node(3, 2, res_type="Lager", storage_basic=7),
+    )
+
+    assert manager.get_storage_report(1)["storage_basic"] == 7
+
+
+def test_get_storage_report_counts_start_node_if_it_is_lager():
+    manager = _storage_manager(_storage_node(1, res_type="Lager", storage_basic=7))
+
+    assert manager.get_storage_report(1)["storage_basic"] == 7
+
+
+def test_get_storage_report_handles_missing_node():
+    report = _storage_manager().get_storage_report("missing")
+
+    assert report == {key: 0 for key in STORAGE_RESOURCE_KEYS}
+
+
+def test_get_storage_report_handles_invalid_child_ids():
+    manager = _storage_manager(_storage_node(1, children=["invalid"]))
+
+    assert manager.get_storage_report(1) == {key: 0 for key in STORAGE_RESOURCE_KEYS}
+
+
+def test_get_storage_report_counts_duplicate_child_reference_once():
+    manager = _storage_manager(
+        _storage_node(1, children=[2, 2]),
+        _storage_node(2, 1, res_type="Lager", storage_basic=7),
+    )
+
+    assert manager.get_storage_report(1)["storage_basic"] == 7
+
+
+def test_get_storage_report_stops_at_cycles():
+    manager = _storage_manager(
+        _storage_node(1, 2, [2], "Lager", storage_basic=3),
+        _storage_node(2, 1, [1], "Lager", storage_basic=7),
+    )
+
+    assert manager.get_storage_report(1)["storage_basic"] == 10
+
+
+def test_get_storage_report_includes_parent_id_child():
+    manager = _storage_manager(
+        _storage_node(1),
+        _storage_node(2, 1, res_type="Lager", storage_basic=7),
+    )
+
+    assert manager.get_storage_report(1)["storage_basic"] == 7
+
+
+def test_get_storage_report_does_not_mutate_world_data():
+    manager = _storage_manager(
+        _storage_node(1, children=[2]),
+        _storage_node(2, 1, res_type="Lager", storage_basic=7),
+    )
+    original = copy.deepcopy(manager.world_data)
+
+    manager.get_storage_report(1)
+
+    assert manager.world_data == original
+
+
+def test_get_storage_report_does_not_write_total_resources():
+    manager = _storage_manager(_storage_node(1))
+
+    manager.get_storage_report(1)
+
+    assert "total_resources" not in manager.world_data["nodes"]["1"]
+
+
+def test_get_storage_report_does_not_write_storage_fields():
+    manager = _storage_manager(_storage_node(1, res_type="Lager"))
+    original = copy.deepcopy(manager.world_data["nodes"]["1"])
+
+    manager.get_storage_report(1)
+
+    assert manager.world_data["nodes"]["1"] == original
 
 
 def test_attempt_link_neighbors_directional():


### PR DESCRIPTION
### Motivation

- Provide a read-only report that returns reported physical storage totals for a subtree without introducing availability, ownership, transfer, taxation, consumption, or economic semantics.
- Ensure the report only counts physical storage originating on `res_type == "Lager"` nodes and delegates node-local decisions to the existing rollup policy.
- Make traversal robust (duplicate children, cycles, invalid/missing IDs) and guarantee no mutation of `world_data`, `storage_*` fields or `total_resources`.

### Description

- Added `WorldManager.get_storage_report(node_id)` in `src/world_manager.py`, importing `STORAGE_RESOURCE_KEYS` and `get_local_storage_contribution` from `src/rollup_policy.py`. The method returns a fresh dict containing exactly the nine `STORAGE_RESOURCE_KEYS` initialized to 0. 
- Traversal is iterative and uses a `visited` set plus a small `parent_lookup` to combine explicit `children` with nodes that reference the current node via `parent_id`; invalid child IDs and missing nodes are ignored safely. Each node is processed at most once and the start node is included. Depth is resolved with `get_depth_of_node` and passed through to `get_local_storage_contribution`. 
- The report accumulates only values returned by `get_local_storage_contribution(node, resource_key, depth=depth)`, so the rollup policy controls which nodes contribute (ensuring Lager-only semantics). The method is strictly read-only and does not write to any node fields. 
- Added focused tests in `tests/test_world_manager.py` covering all required behaviors (presence of all storage keys, Lager-only counting, nested/duplicate/cycle/invalid-child handling, parent_id inclusion, start-node inclusion, and non-mutation guarantees). No UI or schema changes were made.

### Testing

- Ran focused tests: `tests/test_world_manager.py` — 63 passed (all new and existing checks for the world manager behave as expected). 
- Ran rollup tests: `tests/test_rollup_policy.py` — 51 passed. 
- Ran full test suite: `pytest -q` — 331 passed, 80 skipped; overall coverage and repository checks succeeded. 
- Static checks: `python -m py_compile src/world_manager.py src/rollup_policy.py` and `black --check` both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3012be6880832eb19206b994bde7fb)