### PR TITLE
Lägg till presentationshelper för rapporterat fysiskt lager

### DIFF
--- a/src/ui/storage_presentation.py
+++ b/src/ui/storage_presentation.py
@@ -1,0 +1,29 @@
+"""Presentation helpers for reported physical storage."""
+
+_STORAGE_ROWS = (
+    ("storage_basic", "Basresurser (BAS)"),
+    ("storage_luxury", "Lyxresurser (LYX)"),
+    ("storage_silver", "Silver"),
+    ("storage_timber", "Timmer"),
+    ("storage_coal", "Kol"),
+    ("storage_iron_ore", "Järnmalm"),
+    ("storage_iron", "Järn"),
+    ("storage_animal_feed", "Djurfoder"),
+    ("storage_skin", "Skinn"),
+)
+
+
+def build_reported_storage_overview(world_manager, node_id) -> dict:
+    """Build a presentation model for reported physical storage."""
+    report = world_manager.get_storage_report(node_id)
+    rows = tuple(
+        {"key": key, "label": label, "value": report.get(key, 0)}
+        for key, label in _STORAGE_ROWS
+    )
+    return {
+        "title": "Rapporterat fysiskt lager",
+        "help_text": (
+            "Summerat från Lager-noder i området; " "inte automatiskt disponibelt."
+        ),
+        "rows": rows,
+    }

--- a/tests/ui/test_storage_presentation.py
+++ b/tests/ui/test_storage_presentation.py
@@ -1,0 +1,131 @@
+"""Tests for the reported physical storage presentation helper."""
+
+import inspect
+
+import pytest
+
+from src.ui.storage_presentation import build_reported_storage_overview
+
+KEYS = (
+    "storage_basic",
+    "storage_luxury",
+    "storage_silver",
+    "storage_timber",
+    "storage_coal",
+    "storage_iron_ore",
+    "storage_iron",
+    "storage_animal_feed",
+    "storage_skin",
+)
+LABELS = (
+    "Basresurser (BAS)",
+    "Lyxresurser (LYX)",
+    "Silver",
+    "Timmer",
+    "Kol",
+    "Järnmalm",
+    "Järn",
+    "Djurfoder",
+    "Skinn",
+)
+
+
+class StubWorldManager:
+    def __init__(self, report):
+        self.report = report
+        self.reported_node_ids = []
+
+    def get_storage_report(self, node_id):
+        self.reported_node_ids.append(node_id)
+        return self.report
+
+
+def build_overview(report=None, node_id=42):
+    manager = StubWorldManager(report if report is not None else {})
+    return build_reported_storage_overview(manager, node_id), manager
+
+
+def test_reported_storage_overview_uses_world_manager_report():
+    overview, _ = build_overview({"storage_basic": 7})
+    assert overview["rows"][0]["value"] == 7
+
+
+def test_reported_storage_overview_calls_report_with_node_id():
+    _, manager = build_overview(node_id="jarldom-1")
+    assert manager.reported_node_ids == ["jarldom-1"]
+
+
+def test_reported_storage_overview_returns_expected_title():
+    overview, _ = build_overview()
+    assert overview["title"] == "Rapporterat fysiskt lager"
+
+
+def test_reported_storage_overview_returns_required_help_text():
+    overview, _ = build_overview()
+    assert overview["help_text"] == (
+        "Summerat från Lager-noder i området; inte automatiskt disponibelt."
+    )
+
+
+def test_reported_storage_overview_returns_all_nine_rows_in_policy_order():
+    overview, _ = build_overview()
+    assert tuple(row["key"] for row in overview["rows"]) == KEYS
+    assert tuple(row["label"] for row in overview["rows"]) == LABELS
+
+
+def test_reported_storage_overview_uses_consistent_swedish_labels():
+    overview, _ = build_overview()
+    labels = {row["key"]: row["label"] for row in overview["rows"]}
+    assert labels["storage_basic"] == "Basresurser (BAS)"
+    assert labels["storage_luxury"] == "Lyxresurser (LYX)"
+    assert labels["storage_silver"] == "Silver"
+
+
+def test_reported_storage_overview_preserves_zero_values():
+    overview, _ = build_overview(dict.fromkeys(KEYS, 0))
+    assert all(row["value"] == 0 for row in overview["rows"])
+    assert all(type(row["value"]) is int for row in overview["rows"])
+
+
+def test_reported_storage_overview_does_not_use_missing_text():
+    overview, _ = build_overview()
+    assert "Saknas ännu" not in repr(overview)
+
+
+def test_reported_storage_overview_does_not_mix_node_legacy_fields():
+    parameters = inspect.signature(build_reported_storage_overview).parameters
+    assert tuple(parameters) == ("world_manager", "node_id")
+    with pytest.raises(TypeError):
+        build_reported_storage_overview(
+            StubWorldManager({"storage_basic": 7}),
+            42,
+            node_data={"storage_basic": 100},
+        )
+
+
+def test_reported_storage_overview_marks_report_as_not_automatically_available():
+    overview, _ = build_overview()
+    assert "inte automatiskt disponibelt" in overview["help_text"]
+
+
+def test_reported_storage_overview_does_not_claim_ownership_or_tax():
+    overview, _ = build_overview()
+    forbidden = ("ägt", "skattebart", "konsumtion", "förbrukning", "tillgängligt")
+    assert not any(word in overview["help_text"] for word in forbidden)
+
+
+def test_reported_storage_overview_does_not_mutate_report():
+    report = {"storage_basic": 7, "metadata": {"source": "report"}}
+    expected = {"storage_basic": 7, "metadata": {"source": "report"}}
+    build_overview(report)
+    assert report == expected
+
+
+def test_reported_storage_overview_handles_missing_keys_as_zero():
+    overview, _ = build_overview({"storage_basic": 7})
+    assert [row["value"] for row in overview["rows"]] == [7] + [0] * 8
+
+
+def test_reported_storage_overview_values_are_integers():
+    overview, _ = build_overview({key: index for index, key in enumerate(KEYS)})
+    assert all(isinstance(row["value"], int) for row in overview["rows"])


### PR DESCRIPTION
### Motivation

- Behöva ett enkelt, Tk-oberoende presentationslager som omvandlar teknisk lagerrapport från domänlagret till en tydlig viewmodel för UI.
- Säkerställa separation av ansvar genom att enbart använda `WorldManager.get_storage_report(node_id)` som källa och undvika att duplicera eller ändra domänlogik.

### Description

- Ny modul `src/ui/storage_presentation.py` med funktionen `build_reported_storage_overview(world_manager, node_id) -> dict` som anropar `world_manager.get_storage_report(node_id)` och bygger viewmodellen.
- Returnerar en dict med exakt titel `Rapporterat fysiskt lager`, hjälptexten `Summerat från Lager-noder i området; inte automatiskt disponibelt.`, och en `rows`-tuple innehållande nio rader i fast ordning med svenska etiketter.
- Saknade rapportnycklar mappas till numeriskt `0` via `report.get(key, 0)`, och funktionen muterar varken den inkommande rapportdicten eller `world_manager`.
- Inga UI-widgets eller Tk-vyer ändrades och helpern filtrerar/förändrar inte `res_type`, traverserar inte trädet och anropar inte andra domänfunktioner.

### Testing

- Lade till fokuserade tester i `tests/ui/test_storage_presentation.py` som verifierar API-anrop, `node_id`-passering, titel, exakt hjälptext, radordning, etiketter, nollpolicy, heltalsvärden, immutabilitet och att legacyfält inte blandas in; dessa 14 tester passerade lokalt.
- Körningar inkluderade även `tests/test_world_manager.py` och `tests/test_rollup_policy.py` (114 tester) samt hela testsviten; full testsvit gav `345 passed, 80 skipped` och konfigurerad coverage 89.05% på CI-lokalen.
- `python -m py_compile src/ui/storage_presentation.py` och `black --check` för de nya filerna lyckades utan fel.
- Testerna kräver inte Tk/display och använder en enkel stub för `WorldManager.get_storage_report`, så nya tester körs headless och är isolerade från world-data.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a301bff1054832ead0a9f80a08f33ca)