### PR TITLE
Add read-only title seat and jarldom owner domain adapter

### DIFF
--- a/src/world_relations.py
+++ b/src/world_relations.py
@@ -1,0 +1,286 @@
+"""Read-only access to explicit title-seat and jarldom-owner relations."""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional, Set
+
+
+@dataclass(frozen=True)
+class RelationIssue:
+    """A machine-readable problem with an explicit world relation."""
+
+    code: str
+    source_id: Optional[int] = None
+    target_id: Optional[int] = None
+    message: str = ""
+
+
+def _as_id(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        value = value.strip()
+        if value and value.isdigit():
+            return int(value)
+    return None
+
+
+def _mapping(world_data: Any, key: str) -> Mapping[Any, Any]:
+    if not isinstance(world_data, Mapping):
+        return {}
+    value = world_data.get(key)
+    return value if isinstance(value, Mapping) else {}
+
+
+def _nodes(world_data: Any) -> Dict[int, Mapping[str, Any]]:
+    result = {}
+    for raw_id, node in _mapping(world_data, "nodes").items():
+        node_id = _as_id(raw_id)
+        if node_id is None and isinstance(node, Mapping):
+            node_id = _as_id(node.get("node_id"))
+        if node_id is not None and isinstance(node, Mapping):
+            result[node_id] = node
+    return result
+
+
+def _node_depth(nodes: Mapping[int, Mapping[str, Any]], node_id: int) -> Optional[int]:
+    depth = 0
+    current_id = node_id
+    visited = set()
+    while current_id in nodes:
+        if current_id in visited:
+            return None
+        visited.add(current_id)
+        parent_id = _as_id(nodes[current_id].get("parent_id"))
+        if parent_id is None:
+            return depth
+        if parent_id not in nodes:
+            return None
+        current_id = parent_id
+        depth += 1
+    return None  # pragma: no cover - loop exits through the checks above
+
+
+def _is_descendant(
+    nodes: Mapping[int, Mapping[str, Any]], node_id: int, ancestor_id: int
+) -> bool:
+    current_id = node_id
+    visited = set()
+    while current_id in nodes and current_id not in visited:
+        visited.add(current_id)
+        parent_id = _as_id(nodes[current_id].get("parent_id"))
+        if parent_id == ancestor_id:
+            return True
+        if parent_id is None:
+            return False
+        current_id = parent_id
+    return False  # pragma: no cover - guarded fallback for malformed mappings
+
+
+def get_title_seat(world_data: Any, title_id: Any) -> Optional[int]:
+    """Return the seat jarldom id for a title node, if explicitly configured."""
+    wanted_id = _as_id(title_id)
+    if wanted_id is None:
+        return None
+    for raw_title_id, raw_seat_id in _mapping(world_data, "title_seats").items():
+        if _as_id(raw_title_id) == wanted_id:
+            return _as_id(raw_seat_id)
+    return None
+
+
+def get_seated_title(world_data: Any, jarldom_id: Any) -> Optional[int]:
+    """Return the unique title node id using this jarldom as its seat."""
+    wanted_id = _as_id(jarldom_id)
+    if wanted_id is None:
+        return None
+    title_ids = {
+        title_id
+        for raw_title_id, raw_seat_id in _mapping(world_data, "title_seats").items()
+        if _as_id(raw_seat_id) == wanted_id
+        if (title_id := _as_id(raw_title_id)) is not None
+    }
+    return next(iter(title_ids)) if len(title_ids) == 1 else None
+
+
+def get_jarldom_owner(world_data: Any, jarldom_id: Any) -> Optional[int]:
+    """Return the character id explicitly configured to own a jarldom."""
+    wanted_id = _as_id(jarldom_id)
+    if wanted_id is None:
+        return None
+    for raw_jarldom_id, raw_character_id in _mapping(
+        world_data, "jarldom_owners"
+    ).items():
+        if _as_id(raw_jarldom_id) == wanted_id:
+            return _as_id(raw_character_id)
+    return None
+
+
+def get_owned_jarldoms(world_data: Any, character_id: Any) -> List[int]:
+    """Return sorted jarldom ids explicitly owned by the given character id."""
+    wanted_id = _as_id(character_id)
+    if wanted_id is None:
+        return []
+    jarldom_ids = {
+        jarldom_id
+        for raw_jarldom_id, raw_character_id in _mapping(
+            world_data, "jarldom_owners"
+        ).items()
+        if _as_id(raw_character_id) == wanted_id
+        if (jarldom_id := _as_id(raw_jarldom_id)) is not None
+    }
+    return sorted(jarldom_ids)
+
+
+def _issue(
+    code: str,
+    source_id: Optional[int],
+    target_id: Optional[int],
+    message: str,
+) -> RelationIssue:
+    return RelationIssue(code, source_id, target_id, message)
+
+
+def validate_world_relations(
+    world_data: Any, strict: bool = False
+) -> List[RelationIssue]:
+    """Return structured relation issues without mutating world data."""
+    nodes = _nodes(world_data)
+    issues = []
+    configured_titles: Set[int] = set()
+    configured_jarldoms: Set[int] = set()
+    seats_to_titles: Dict[int, List[int]] = {}
+
+    for raw_title_id, raw_seat_id in _mapping(world_data, "title_seats").items():
+        title_id = _as_id(raw_title_id)
+        seat_id = _as_id(raw_seat_id)
+        if title_id is not None:
+            configured_titles.add(title_id)
+        if title_id is None or title_id not in nodes:
+            issues.append(
+                _issue(
+                    "unknown_title_node",
+                    title_id,
+                    seat_id,
+                    "Title-seat source does not identify an existing node.",
+                )
+            )
+        elif _node_depth(nodes, title_id) not in {0, 1, 2}:
+            issues.append(
+                _issue(
+                    "seat_source_not_title",
+                    title_id,
+                    seat_id,
+                    "Title-seat source is not a level 0-2 title.",
+                )
+            )
+
+        if seat_id is None or seat_id not in nodes:
+            issues.append(
+                _issue(
+                    "unknown_seat_node",
+                    title_id,
+                    seat_id,
+                    "Configured seat does not identify an existing node.",
+                )
+            )
+            continue
+        seats_to_titles.setdefault(seat_id, []).append(title_id)
+        if _node_depth(nodes, seat_id) != 3:
+            issues.append(
+                _issue(
+                    "seat_not_jarldom",
+                    title_id,
+                    seat_id,
+                    "Configured seat is not a level 3 jarldom.",
+                )
+            )
+        elif (
+            title_id is not None
+            and title_id in nodes
+            and not _is_descendant(nodes, seat_id, title_id)
+        ):
+            issues.append(
+                _issue(
+                    "seat_outside_title_subtree",
+                    title_id,
+                    seat_id,
+                    "Configured seat is outside the title subtree.",
+                )
+            )
+
+    for seat_id, title_ids in seats_to_titles.items():
+        if len(title_ids) > 1:
+            for title_id in title_ids:
+                issues.append(
+                    _issue(
+                        "duplicate_title_seat",
+                        title_id,
+                        seat_id,
+                        "Jarldom is configured as the seat of multiple titles.",
+                    )
+                )
+
+    character_ids = {
+        character_id
+        for raw_id in _mapping(world_data, "characters")
+        if (character_id := _as_id(raw_id)) is not None
+    }
+    for raw_jarldom_id, raw_character_id in _mapping(
+        world_data, "jarldom_owners"
+    ).items():
+        jarldom_id = _as_id(raw_jarldom_id)
+        character_id = _as_id(raw_character_id)
+        if jarldom_id is not None:
+            configured_jarldoms.add(jarldom_id)
+        if jarldom_id is None or jarldom_id not in nodes:
+            issues.append(
+                _issue(
+                    "unknown_owner_jarldom",
+                    jarldom_id,
+                    character_id,
+                    "Owner source does not identify an existing node.",
+                )
+            )
+        elif _node_depth(nodes, jarldom_id) != 3:
+            issues.append(
+                _issue(
+                    "owner_key_not_jarldom",
+                    jarldom_id,
+                    character_id,
+                    "Owner source is not a level 3 jarldom.",
+                )
+            )
+        if character_id is None or character_id not in character_ids:
+            issues.append(
+                _issue(
+                    "unknown_owner_character",
+                    jarldom_id,
+                    character_id,
+                    "Owner target is not in the global character registry.",
+                )
+            )
+
+    if strict:
+        for node_id in sorted(nodes):
+            depth = _node_depth(nodes, node_id)
+            if depth in {0, 1, 2} and node_id not in configured_titles:
+                issues.append(
+                    _issue(
+                        "title_missing_seat",
+                        node_id,
+                        None,
+                        "Title has no explicitly configured seat.",
+                    )
+                )
+            elif depth == 3 and node_id not in configured_jarldoms:
+                issues.append(
+                    _issue(
+                        "jarldom_missing_owner",
+                        node_id,
+                        None,
+                        "Jarldom has no explicitly configured owner.",
+                    )
+                )
+
+    return issues

--- a/tests/domain/test_world_relations.py
+++ b/tests/domain/test_world_relations.py
@@ -1,0 +1,260 @@
+import copy
+
+from world_relations import (
+    RelationIssue,
+    get_jarldom_owner,
+    get_owned_jarldoms,
+    get_seated_title,
+    get_title_seat,
+    validate_world_relations,
+)
+
+
+def make_world():
+    return {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None},
+            "2": {"node_id": 2, "parent_id": 1},
+            "3": {"node_id": 3, "parent_id": 2},
+            "4": {"node_id": 4, "parent_id": 3},
+            "5": {"node_id": 5, "parent_id": 1},
+            "6": {"node_id": 6, "parent_id": 5},
+            "7": {"node_id": 7, "parent_id": 6},
+            "8": {"node_id": 8, "parent_id": 4},
+        },
+        "characters": {"10": {"name": "Owner"}, "11": {"name": "Other"}},
+    }
+
+
+def issue_codes(world_data, strict=False):
+    return {issue.code for issue in validate_world_relations(world_data, strict=strict)}
+
+
+def test_missing_relation_indexes_are_empty_without_mutation():
+    world_data = make_world()
+    original = copy.deepcopy(world_data)
+
+    assert get_title_seat(world_data, 1) is None
+    assert get_seated_title(world_data, 4) is None
+    assert get_jarldom_owner(world_data, 4) is None
+    assert get_owned_jarldoms(world_data, 10) == []
+    assert validate_world_relations(world_data) == []
+    assert world_data == original
+
+
+def test_relation_queries_accept_string_encoded_ids():
+    world_data = make_world()
+    world_data["title_seats"] = {"1": "4"}
+    world_data["jarldom_owners"] = {"4": "10"}
+
+    assert get_title_seat(world_data, "1") == 4
+    assert get_seated_title(world_data, "4") == 1
+    assert get_jarldom_owner(world_data, "4") == 10
+    assert get_owned_jarldoms(world_data, "10") == [4]
+
+
+def test_unknown_top_level_data_is_untouched():
+    world_data = make_world()
+    world_data["future_data"] = {"nested": [1, 2, 3]}
+    original = copy.deepcopy(world_data)
+
+    validate_world_relations(world_data, strict=True)
+
+    assert world_data == original
+
+
+def test_get_title_seat_returns_level_three_descendant():
+    world_data = make_world()
+    world_data["title_seats"] = {"2": "4"}
+
+    assert get_title_seat(world_data, 2) == 4
+
+
+def test_get_seated_title_returns_unique_title():
+    world_data = make_world()
+    world_data["title_seats"] = {"2": "4"}
+
+    assert get_seated_title(world_data, 4) == 2
+
+
+def test_get_seated_title_returns_none_for_duplicate_seat():
+    world_data = make_world()
+    world_data["title_seats"] = {"1": "4", "2": "4"}
+
+    assert get_seated_title(world_data, 4) is None
+
+
+def test_validation_reports_title_without_seat_in_strict_mode():
+    world_data = make_world()
+
+    assert "title_missing_seat" not in issue_codes(world_data)
+    assert "title_missing_seat" in issue_codes(world_data, strict=True)
+
+
+def test_validation_reports_unknown_title_node():
+    world_data = make_world()
+    world_data["title_seats"] = {"999": "4"}
+
+    assert "unknown_title_node" in issue_codes(world_data)
+
+
+def test_validation_reports_non_title_source():
+    world_data = make_world()
+    world_data["title_seats"] = {"4": "7"}
+
+    assert "seat_source_not_title" in issue_codes(world_data)
+
+
+def test_validation_reports_unknown_seat_node():
+    world_data = make_world()
+    world_data["title_seats"] = {"2": "999"}
+
+    assert "unknown_seat_node" in issue_codes(world_data)
+
+
+def test_validation_reports_non_jarldom_seat():
+    world_data = make_world()
+    world_data["title_seats"] = {"1": "3", "2": "8"}
+
+    assert "seat_not_jarldom" in issue_codes(world_data)
+
+
+def test_validation_reports_seat_outside_title_subtree():
+    world_data = make_world()
+    world_data["title_seats"] = {"2": "7"}
+
+    assert "seat_outside_title_subtree" in issue_codes(world_data)
+
+
+def test_validation_reports_duplicate_seat():
+    world_data = make_world()
+    world_data["title_seats"] = {"1": "4", "2": "4"}
+
+    issues = validate_world_relations(world_data)
+
+    assert [issue.code for issue in issues].count("duplicate_title_seat") == 2
+
+
+def test_get_jarldom_owner_returns_existing_character():
+    world_data = make_world()
+    world_data["jarldom_owners"] = {"4": "10"}
+
+    assert get_jarldom_owner(world_data, 4) == 10
+
+
+def test_get_owned_jarldoms_returns_multiple_jarldoms_for_same_character():
+    world_data = make_world()
+    world_data["jarldom_owners"] = {"4": "10", "7": 10}
+
+    assert get_owned_jarldoms(world_data, 10) == [4, 7]
+
+
+def test_validation_reports_owner_key_on_non_jarldom():
+    world_data = make_world()
+    world_data["jarldom_owners"] = {"3": "10", "8": "10"}
+
+    assert "owner_key_not_jarldom" in issue_codes(world_data)
+
+
+def test_validation_reports_unknown_owner_jarldom():
+    world_data = make_world()
+    world_data["jarldom_owners"] = {"999": "10"}
+
+    assert "unknown_owner_jarldom" in issue_codes(world_data)
+
+
+def test_validation_reports_unknown_owner_character():
+    world_data = make_world()
+    world_data["jarldom_owners"] = {"4": "999"}
+
+    assert "unknown_owner_character" in issue_codes(world_data)
+
+
+def test_validation_uses_only_global_character_registry():
+    world_data = make_world()
+    world_data["nodes"]["4"]["characters"] = [{"id": 99}]
+    world_data["jarldom_owners"] = {"4": "99"}
+
+    assert "unknown_owner_character" in issue_codes(world_data)
+
+
+def test_validation_reports_jarldom_without_owner_in_strict_mode():
+    world_data = make_world()
+
+    assert "jarldom_missing_owner" not in issue_codes(world_data)
+    assert "jarldom_missing_owner" in issue_codes(world_data, strict=True)
+
+
+def test_relation_adapter_ignores_personal_province_owner_fields():
+    world_data = make_world()
+    world_data["nodes"]["4"].update(
+        {"owner_assigned_id": 10, "owner_assigned_level": "jarldom"}
+    )
+
+    assert get_title_seat(world_data, 3) is None
+    assert get_jarldom_owner(world_data, 4) is None
+
+
+def test_relation_adapter_does_not_infer_owner_from_ruler_id():
+    world_data = make_world()
+    world_data["nodes"]["4"]["ruler_id"] = 10
+
+    assert get_jarldom_owner(world_data, 4) is None
+
+
+def test_relation_adapter_does_not_infer_seat_from_personal_province_path():
+    world_data = make_world()
+    world_data["nodes"]["2"]["personal_province_path"] = [2, 3, 4]
+
+    assert get_title_seat(world_data, 2) is None
+
+
+def test_validation_handles_parent_cycle_without_crashing():
+    world_data = make_world()
+    world_data["nodes"]["2"]["parent_id"] = 3
+    world_data["title_seats"] = {"2": "4"}
+
+    assert "seat_source_not_title" in issue_codes(world_data)
+
+
+def test_invalid_ids_do_not_crash_queries_or_validation():
+    world_data = make_world()
+    world_data["title_seats"] = {"bad": "", None: []}
+    world_data["jarldom_owners"] = {"bad": {}, "4": "not-a-character"}
+
+    assert get_title_seat(world_data, "") is None
+    assert get_seated_title(world_data, object()) is None
+    assert get_jarldom_owner(world_data, True) is None
+    assert get_owned_jarldoms(world_data, "invalid") == []
+    assert {
+        "unknown_title_node",
+        "unknown_seat_node",
+        "unknown_owner_jarldom",
+        "unknown_owner_character",
+    }.issubset(issue_codes(world_data))
+
+
+def test_non_mapping_world_data_is_treated_as_empty():
+    assert get_title_seat(None, 1) is None
+    assert validate_world_relations([]) == []
+
+
+def test_validation_accepts_node_id_when_node_key_is_invalid():
+    world_data = {
+        "nodes": {
+            "invalid-key": {"node_id": 1, "parent_id": None},
+            "2": {"node_id": 2, "parent_id": 999},
+        },
+        "title_seats": {"1": "2"},
+    }
+
+    assert "seat_not_jarldom" in issue_codes(world_data)
+
+
+def test_relation_issue_is_frozen_and_machine_readable():
+    issue = RelationIssue("example", 1, 2, "message")
+
+    assert issue.code == "example"
+    assert issue.source_id == 1
+    assert issue.target_id == 2
+    assert issue.message == "message"


### PR DESCRIPTION
### Motivation
- Introduce a small, isolated read-only adapter to surface explicit `title_seats` and `jarldom_owners` relations from `world_data` without mixing those relations with existing node fields like `owner_assigned_id`, `ruler_id` or `personal_province_path`.
- Ensure old worlds lacking the new top-level indexes remain readable (treat missing indexes as empty) and avoid any mutation or migration of `world_data`.
- Provide machine-readable validation for these new explicit relations so consumers can detect, report and act on problems without changing core models or UI.

### Description
- Added `src/world_relations.py` implementing a read-only API: `get_title_seat`, `get_seated_title`, `get_jarldom_owner`, `get_owned_jarldoms` and `validate_world_relations` plus a frozen `RelationIssue` dataclass for structured problems.
- Implemented safe ID handling (accept int and numeric-string IDs, treat non-numeric/boolean as invalid), local node-depth calculation and parent-chain descendant checks with cycle protection, and only read top-level `title_seats`, `jarldom_owners` and `characters` mappings from `world_data`.
- Implemented full validation producing requested issue codes (unknown/invalid title or seat nodes, non-title/ non-jarldom keys, seat outside subtree, duplicate seats, unknown owner characters, and strict-mode missing-seat/ missing-owner checks) and ensured the module does not import or depend on `WorldManager`, `Node` or any UI/serialization code.

### Testing
- Added `tests/domain/test_world_relations.py` with focused dict-based fixtures covering all public functions, validation codes, strict/non-strict modes, malformed IDs, parent cycles, non-mutation guarantees and the required separation from `owner_assigned_*` and `ruler_id` semantics; all tests pass for the adapter.
- Ran adapter-focused checks: `python -m pytest -q -o addopts='--cov=world_relations --cov-report=term-missing' tests/domain/test_world_relations.py` — 28 passed and 100% statement coverage for `src/world_relations.py`.
- Ran full project checks: `python -m pytest -q` — full suite passed (385 passed, 110 skipped, 1 pre-existing warning), `python -m py_compile src/world_relations.py` and `black --check` on the new files also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a305620a088832ea2521c37fe17178f)