### PR TITLE
Add atomic write APIs for title seats and jarldom owners

### DIFF
--- a/src/world_relations.py
+++ b/src/world_relations.py
@@ -1,4 +1,4 @@
-"""Read-only access to explicit title-seat and jarldom-owner relations."""
+"""Access to explicit title-seat and jarldom-owner relations."""
 
 from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, Optional, Set
@@ -139,6 +139,228 @@ def _issue(
     message: str,
 ) -> RelationIssue:
     return RelationIssue(code, source_id, target_id, message)
+
+
+def _validate_title(
+    world_data: Any, raw_title_id: Any
+) -> tuple[Optional[int], List[RelationIssue]]:
+    title_id = _as_id(raw_title_id)
+    if title_id is None:
+        return None, [
+            _issue(
+                "invalid_title_id",
+                None,
+                None,
+                "Title id must be an integer or numeric string.",
+            )
+        ]
+    nodes = _nodes(world_data)
+    if title_id not in nodes:
+        return title_id, [
+            _issue(
+                "unknown_title_node",
+                title_id,
+                None,
+                "Title id does not identify an existing node.",
+            )
+        ]
+    if _node_depth(nodes, title_id) not in {0, 1, 2}:
+        return title_id, [
+            _issue(
+                "seat_source_not_title",
+                title_id,
+                None,
+                "Title-seat source is not a level 0-2 title.",
+            )
+        ]
+    return title_id, []
+
+
+def _validate_jarldom(
+    world_data: Any, raw_jarldom_id: Any
+) -> tuple[Optional[int], List[RelationIssue]]:
+    jarldom_id = _as_id(raw_jarldom_id)
+    if jarldom_id is None:
+        return None, [
+            _issue(
+                "invalid_jarldom_id",
+                None,
+                None,
+                "Jarldom id must be an integer or numeric string.",
+            )
+        ]
+    nodes = _nodes(world_data)
+    if jarldom_id not in nodes:
+        return jarldom_id, [
+            _issue(
+                "unknown_owner_jarldom",
+                jarldom_id,
+                None,
+                "Jarldom id does not identify an existing node.",
+            )
+        ]
+    if _node_depth(nodes, jarldom_id) != 3:
+        return jarldom_id, [
+            _issue(
+                "owner_key_not_jarldom",
+                jarldom_id,
+                None,
+                "Owner source is not a level 3 jarldom.",
+            )
+        ]
+    return jarldom_id, []
+
+
+def set_title_seat(
+    world_data: Any, title_id: Any, jarldom_id: Any
+) -> List[RelationIssue]:
+    """Set a title's seat jarldom if valid. Return issues; mutate only on success."""
+    normalized_title_id, issues = _validate_title(world_data, title_id)
+    normalized_seat_id = _as_id(jarldom_id)
+    if normalized_seat_id is None:
+        issues.append(
+            _issue(
+                "invalid_seat_id",
+                normalized_title_id,
+                None,
+                "Seat id must be an integer or numeric string.",
+            )
+        )
+    else:
+        nodes = _nodes(world_data)
+        if normalized_seat_id not in nodes:
+            issues.append(
+                _issue(
+                    "unknown_seat_node",
+                    normalized_title_id,
+                    normalized_seat_id,
+                    "Seat id does not identify an existing node.",
+                )
+            )
+        elif _node_depth(nodes, normalized_seat_id) != 3:
+            issues.append(
+                _issue(
+                    "seat_not_jarldom",
+                    normalized_title_id,
+                    normalized_seat_id,
+                    "Configured seat is not a level 3 jarldom.",
+                )
+            )
+        elif normalized_title_id is not None and not _is_descendant(
+            nodes, normalized_seat_id, normalized_title_id
+        ):
+            issues.append(
+                _issue(
+                    "seat_outside_title_subtree",
+                    normalized_title_id,
+                    normalized_seat_id,
+                    "Configured seat is outside the title subtree.",
+                )
+            )
+
+    for raw_other_title_id, raw_seat_id in _mapping(world_data, "title_seats").items():
+        other_title_id = _as_id(raw_other_title_id)
+        if (
+            normalized_seat_id is not None
+            and _as_id(raw_seat_id) == normalized_seat_id
+            and other_title_id != normalized_title_id
+        ):
+            issues.append(
+                _issue(
+                    "duplicate_title_seat",
+                    normalized_title_id,
+                    normalized_seat_id,
+                    "Jarldom is already configured as another title's seat.",
+                )
+            )
+            break
+
+    if issues:
+        return issues
+
+    updated_seats = {
+        key: value
+        for key, value in _mapping(world_data, "title_seats").items()
+        if _as_id(key) != normalized_title_id
+    }
+    updated_seats[str(normalized_title_id)] = str(normalized_seat_id)
+    world_data["title_seats"] = updated_seats
+    return []
+
+
+def clear_title_seat(world_data: Any, title_id: Any) -> List[RelationIssue]:
+    """Clear a title's configured seat. Return issues; mutate only on success."""
+    normalized_title_id, issues = _validate_title(world_data, title_id)
+    if issues:
+        return issues
+
+    seats = _mapping(world_data, "title_seats")
+    if not any(_as_id(key) == normalized_title_id for key in seats):
+        return []
+    world_data["title_seats"] = {
+        key: value for key, value in seats.items() if _as_id(key) != normalized_title_id
+    }
+    return []
+
+
+def set_jarldom_owner(
+    world_data: Any, jarldom_id: Any, character_id: Any
+) -> List[RelationIssue]:
+    """Set a jarldom's owner character if valid. Return issues; mutate only on success."""
+    normalized_jarldom_id, issues = _validate_jarldom(world_data, jarldom_id)
+    normalized_character_id = _as_id(character_id)
+    if normalized_character_id is None:
+        issues.append(
+            _issue(
+                "invalid_character_id",
+                normalized_jarldom_id,
+                None,
+                "Character id must be an integer or numeric string.",
+            )
+        )
+    else:
+        character_ids = {
+            candidate_id
+            for raw_id in _mapping(world_data, "characters")
+            if (candidate_id := _as_id(raw_id)) is not None
+        }
+        if normalized_character_id not in character_ids:
+            issues.append(
+                _issue(
+                    "unknown_owner_character",
+                    normalized_jarldom_id,
+                    normalized_character_id,
+                    "Owner target is not in the global character registry.",
+                )
+            )
+    if issues:
+        return issues
+
+    updated_owners = {
+        key: value
+        for key, value in _mapping(world_data, "jarldom_owners").items()
+        if _as_id(key) != normalized_jarldom_id
+    }
+    updated_owners[str(normalized_jarldom_id)] = str(normalized_character_id)
+    world_data["jarldom_owners"] = updated_owners
+    return []
+
+
+def clear_jarldom_owner(world_data: Any, jarldom_id: Any) -> List[RelationIssue]:
+    """Clear a jarldom's configured owner. Return issues; mutate only on success."""
+    normalized_jarldom_id, issues = _validate_jarldom(world_data, jarldom_id)
+    if issues:
+        return issues
+
+    owners = _mapping(world_data, "jarldom_owners")
+    if not any(_as_id(key) == normalized_jarldom_id for key in owners):
+        return []
+    world_data["jarldom_owners"] = {
+        key: value
+        for key, value in owners.items()
+        if _as_id(key) != normalized_jarldom_id
+    }
+    return []
 
 
 def validate_world_relations(

--- a/tests/domain/test_world_relations.py
+++ b/tests/domain/test_world_relations.py
@@ -2,10 +2,14 @@ import copy
 
 from world_relations import (
     RelationIssue,
+    clear_jarldom_owner,
+    clear_title_seat,
     get_jarldom_owner,
     get_owned_jarldoms,
     get_seated_title,
     get_title_seat,
+    set_jarldom_owner,
+    set_title_seat,
     validate_world_relations,
 )
 
@@ -258,3 +262,318 @@ def test_relation_issue_is_frozen_and_machine_readable():
     assert issue.source_id == 1
     assert issue.target_id == 2
     assert issue.message == "message"
+
+
+def assert_rejected_without_mutation(function, world_data, *args):
+    original = copy.deepcopy(world_data)
+
+    issues = function(world_data, *args)
+
+    assert issues
+    assert world_data == original
+    return {issue.code for issue in issues}
+
+
+def test_set_title_seat_creates_index_on_success():
+    world_data = make_world()
+
+    set_title_seat(world_data, "2", 4)
+
+    assert world_data["title_seats"] == {"2": "4"}
+
+
+def test_set_title_seat_returns_no_issues_on_success():
+    assert set_title_seat(make_world(), 2, 4) == []
+
+
+def test_set_title_seat_is_idempotent_for_same_relation():
+    world_data = make_world()
+    set_title_seat(world_data, 2, 4)
+    original = copy.deepcopy(world_data)
+
+    assert set_title_seat(world_data, "2", "4") == []
+    assert world_data == original
+
+
+def test_set_title_seat_can_replace_same_titles_seat():
+    world_data = make_world()
+    world_data["nodes"]["9"] = {"node_id": 9, "parent_id": 3}
+    world_data["title_seats"] = {"2": "4"}
+
+    assert set_title_seat(world_data, 2, 9) == []
+    assert world_data["title_seats"] == {"2": "9"}
+
+
+def test_set_title_seat_rejects_unknown_title_without_mutation():
+    codes = assert_rejected_without_mutation(set_title_seat, make_world(), 999, 4)
+    assert "unknown_title_node" in codes
+
+
+def test_set_title_seat_rejects_non_title_source_without_mutation():
+    codes = assert_rejected_without_mutation(set_title_seat, make_world(), 4, 4)
+    assert "seat_source_not_title" in codes
+
+
+def test_set_title_seat_rejects_unknown_seat_without_mutation():
+    codes = assert_rejected_without_mutation(set_title_seat, make_world(), 2, 999)
+    assert "unknown_seat_node" in codes
+
+
+def test_set_title_seat_rejects_non_jarldom_seat_without_mutation():
+    codes = assert_rejected_without_mutation(set_title_seat, make_world(), 2, 3)
+    assert "seat_not_jarldom" in codes
+
+
+def test_set_title_seat_rejects_seat_outside_subtree_without_mutation():
+    codes = assert_rejected_without_mutation(set_title_seat, make_world(), 2, 7)
+    assert "seat_outside_title_subtree" in codes
+
+
+def test_set_title_seat_rejects_duplicate_seat_for_other_title_without_mutation():
+    world_data = make_world()
+    world_data["title_seats"] = {"1": "4"}
+
+    codes = assert_rejected_without_mutation(set_title_seat, world_data, 2, 4)
+
+    assert "duplicate_title_seat" in codes
+
+
+def test_set_title_seat_rejects_invalid_ids_without_mutation():
+    world_data = make_world()
+    codes = assert_rejected_without_mutation(set_title_seat, world_data, "bad", [])
+    assert {"invalid_title_id", "invalid_seat_id"}.issubset(codes)
+    assert "title_seats" not in world_data
+
+
+def test_set_title_seat_does_not_touch_personal_province_fields():
+    world_data = make_world()
+    world_data["nodes"]["2"].update(
+        {
+            "owner_assigned_id": 10,
+            "owner_assigned_level": 2,
+            "personal_province_path": [2, 3, 4],
+        }
+    )
+    node_before = copy.deepcopy(world_data["nodes"]["2"])
+
+    set_title_seat(world_data, 2, 4)
+
+    assert world_data["nodes"]["2"] == node_before
+
+
+def test_set_title_seat_does_not_touch_ruler_fields():
+    world_data = make_world()
+    world_data["nodes"]["2"]["ruler_id"] = 10
+    world_data["characters"]["10"]["ruler_of"] = [2]
+    original_nodes = copy.deepcopy(world_data["nodes"])
+    original_characters = copy.deepcopy(world_data["characters"])
+
+    set_title_seat(world_data, 2, 4)
+
+    assert world_data["nodes"] == original_nodes
+    assert world_data["characters"] == original_characters
+
+
+def test_clear_title_seat_removes_only_that_title_relation():
+    world_data = make_world()
+    world_data["title_seats"] = {"1": "7", "2": "4"}
+
+    assert clear_title_seat(world_data, 2) == []
+    assert world_data["title_seats"] == {"1": "7"}
+
+
+def test_clear_title_seat_noops_when_index_missing():
+    world_data = make_world()
+    original = copy.deepcopy(world_data)
+
+    assert clear_title_seat(world_data, 2) == []
+    assert world_data == original
+
+
+def test_clear_title_seat_noops_when_title_has_no_seat():
+    world_data = make_world()
+    world_data["title_seats"] = {"1": "7"}
+    original = copy.deepcopy(world_data)
+
+    assert clear_title_seat(world_data, 2) == []
+    assert world_data == original
+
+
+def test_clear_title_seat_rejects_unknown_title_without_mutation():
+    codes = assert_rejected_without_mutation(clear_title_seat, make_world(), 999)
+    assert "unknown_title_node" in codes
+
+
+def test_clear_title_seat_rejects_non_title_without_mutation():
+    codes = assert_rejected_without_mutation(clear_title_seat, make_world(), 4)
+    assert "seat_source_not_title" in codes
+
+
+def test_clear_title_seat_rejects_invalid_id_without_mutation():
+    codes = assert_rejected_without_mutation(clear_title_seat, make_world(), True)
+    assert "invalid_title_id" in codes
+
+
+def test_set_jarldom_owner_creates_index_on_success():
+    world_data = make_world()
+
+    set_jarldom_owner(world_data, "4", 10)
+
+    assert world_data["jarldom_owners"] == {"4": "10"}
+
+
+def test_set_jarldom_owner_returns_no_issues_on_success():
+    assert set_jarldom_owner(make_world(), 4, 10) == []
+
+
+def test_set_jarldom_owner_is_idempotent_for_same_relation():
+    world_data = make_world()
+    set_jarldom_owner(world_data, 4, 10)
+    original = copy.deepcopy(world_data)
+
+    assert set_jarldom_owner(world_data, "4", "10") == []
+    assert world_data == original
+
+
+def test_set_jarldom_owner_can_replace_owner():
+    world_data = make_world()
+    world_data["jarldom_owners"] = {"4": "10"}
+
+    assert set_jarldom_owner(world_data, 4, 11) == []
+    assert world_data["jarldom_owners"] == {"4": "11"}
+
+
+def test_set_jarldom_owner_allows_same_character_to_own_multiple_jarldoms():
+    world_data = make_world()
+
+    assert set_jarldom_owner(world_data, 4, 10) == []
+    assert set_jarldom_owner(world_data, 7, 10) == []
+    assert world_data["jarldom_owners"] == {"4": "10", "7": "10"}
+
+
+def test_set_jarldom_owner_rejects_unknown_jarldom_without_mutation():
+    codes = assert_rejected_without_mutation(set_jarldom_owner, make_world(), 999, 10)
+    assert "unknown_owner_jarldom" in codes
+
+
+def test_set_jarldom_owner_rejects_non_jarldom_key_without_mutation():
+    codes = assert_rejected_without_mutation(set_jarldom_owner, make_world(), 3, 10)
+    assert "owner_key_not_jarldom" in codes
+
+
+def test_set_jarldom_owner_rejects_unknown_character_without_mutation():
+    codes = assert_rejected_without_mutation(set_jarldom_owner, make_world(), 4, 999)
+    assert "unknown_owner_character" in codes
+
+
+def test_set_jarldom_owner_rejects_invalid_ids_without_mutation():
+    world_data = make_world()
+    codes = assert_rejected_without_mutation(
+        set_jarldom_owner, world_data, object(), False
+    )
+    assert {"invalid_jarldom_id", "invalid_character_id"}.issubset(codes)
+    assert "jarldom_owners" not in world_data
+
+
+def test_set_jarldom_owner_does_not_infer_or_touch_ruler_id():
+    world_data = make_world()
+    world_data["nodes"]["4"]["ruler_id"] = 11
+    original_nodes = copy.deepcopy(world_data["nodes"])
+
+    assert set_jarldom_owner(world_data, 4, 10) == []
+    assert world_data["jarldom_owners"] == {"4": "10"}
+    assert world_data["nodes"] == original_nodes
+
+
+def test_set_jarldom_owner_does_not_touch_owner_assigned_fields():
+    world_data = make_world()
+    world_data["nodes"]["4"].update(
+        {"owner_assigned_id": 11, "owner_assigned_level": 3}
+    )
+    original_nodes = copy.deepcopy(world_data["nodes"])
+
+    set_jarldom_owner(world_data, 4, 10)
+
+    assert world_data["nodes"] == original_nodes
+
+
+def test_clear_jarldom_owner_removes_only_that_jarldom_relation():
+    world_data = make_world()
+    world_data["jarldom_owners"] = {"4": "10", "7": "11"}
+
+    assert clear_jarldom_owner(world_data, 4) == []
+    assert world_data["jarldom_owners"] == {"7": "11"}
+
+
+def test_clear_jarldom_owner_noops_when_index_missing():
+    world_data = make_world()
+    original = copy.deepcopy(world_data)
+
+    assert clear_jarldom_owner(world_data, 4) == []
+    assert world_data == original
+
+
+def test_clear_jarldom_owner_noops_when_jarldom_has_no_owner():
+    world_data = make_world()
+    world_data["jarldom_owners"] = {"7": "11"}
+    original = copy.deepcopy(world_data)
+
+    assert clear_jarldom_owner(world_data, 4) == []
+    assert world_data == original
+
+
+def test_clear_jarldom_owner_rejects_unknown_jarldom_without_mutation():
+    codes = assert_rejected_without_mutation(clear_jarldom_owner, make_world(), 999)
+    assert "unknown_owner_jarldom" in codes
+
+
+def test_clear_jarldom_owner_rejects_non_jarldom_without_mutation():
+    codes = assert_rejected_without_mutation(clear_jarldom_owner, make_world(), 3)
+    assert "owner_key_not_jarldom" in codes
+
+
+def test_clear_jarldom_owner_rejects_invalid_id_without_mutation():
+    codes = assert_rejected_without_mutation(
+        clear_jarldom_owner, make_world(), "not-an-id"
+    )
+    assert "invalid_jarldom_id" in codes
+
+
+def test_read_queries_see_values_written_by_setters():
+    world_data = make_world()
+
+    set_title_seat(world_data, 2, 4)
+    set_jarldom_owner(world_data, 4, 10)
+    set_jarldom_owner(world_data, 7, 10)
+
+    assert get_title_seat(world_data, 2) == 4
+    assert get_seated_title(world_data, 4) == 2
+    assert get_jarldom_owner(world_data, 4) == 10
+    assert get_owned_jarldoms(world_data, 10) == [4, 7]
+
+
+def test_validate_world_relations_accepts_values_written_by_setters():
+    world_data = make_world()
+
+    set_title_seat(world_data, 2, 4)
+    set_jarldom_owner(world_data, 4, 10)
+
+    assert validate_world_relations(world_data) == []
+
+
+def test_failed_title_seat_update_leaves_world_data_exactly_unchanged():
+    world_data = make_world()
+    world_data["title_seats"] = {"2": "4"}
+    original = copy.deepcopy(world_data)
+
+    assert set_title_seat(world_data, 2, 7)
+    assert world_data == original
+
+
+def test_failed_jarldom_owner_update_leaves_world_data_exactly_unchanged():
+    world_data = make_world()
+    world_data["jarldom_owners"] = {"4": "10"}
+    original = copy.deepcopy(world_data)
+
+    assert set_jarldom_owner(world_data, 4, 999)
+    assert world_data == original


### PR DESCRIPTION
### Motivation

- Add explicit, validated write operations for title-seat and jarldom-owner relations so relations can be configured through a safe API while keeping domain responsibilities separated. 
- Ensure writes are fully validated and atomic, so invalid updates never mutate `world_data` and the read-only adapter remains compatible.

### Description

- Implemented four new APIs in `src/world_relations.py`: `set_title_seat(world_data, title_id, jarldom_id)`, `clear_title_seat(world_data, title_id)`, `set_jarldom_owner(world_data, jarldom_id, character_id)`, and `clear_jarldom_owner(world_data, jarldom_id)`, each returning `list[RelationIssue]` and validating before any mutation. 
- Added helper validators `_validate_title` and `_validate_jarldom`, and new issue codes `invalid_title_id`, `invalid_seat_id`, `invalid_jarldom_id`, and `invalid_character_id`; the existing `RelationIssue` dataclass was reused as-is. 
- Writes are constrained to the explicit indexes `world_data["title_seats"]` and `world_data["jarldom_owners"]` only, keys and values are stored as strings, and read-only query functions still return ints via the existing normalization. 
- Files changed: `src/world_relations.py` and `tests/domain/test_world_relations.py` (diff: 2 files changed, 542 insertions, 1 deletion); implementation avoids touching Node, WorldManager, UI, serialization, migrations, or any personal-province/ruler/owner_assigned fields.

### Testing

- Ran the focused domain tests with `python -m pytest -q tests/domain/test_world_relations.py` and observed `68 passed` (all new and existing domain assertions passed). 
- Ran the full test suite with `python -m pytest -q` and observed `425 passed, 110 skipped` and overall coverage `89.05%`. 
- Performed static checks: `python -m py_compile src/world_relations.py` and `python -m black --check src/world_relations.py tests/domain/test_world_relations.py` which both succeeded. 
- Tests include focused cases for success, idempotence, replacement, invalid inputs, subtree/level/duplicate detection, no-op clears, and atomicity (failed updates leave `world_data` exactly unchanged).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a305fbb9688832e8de044896cb49f70)