### PR TITLE
Add read-only world relations presentation helper

### DIFF
--- a/src/ui/world_relations_presentation.py
+++ b/src/ui/world_relations_presentation.py
@@ -1,0 +1,204 @@
+"""Read-only presentation helpers for explicit world relations."""
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import world_relations
+
+_WARNING_LABELS = {
+    "title_missing_seat": "Titeln saknar angivet säte.",
+    "duplicate_title_seat": ("Jarldömet används redan som säte för en annan titel."),
+    "seat_outside_title_subtree": "Sätet ligger utanför titelns område.",
+    "unknown_seat_node": "Det angivna sätet finns inte längre.",
+    "seat_not_jarldom": "Det angivna sätet är inte ett jarldöme.",
+    "unknown_title_node": "Titeln finns inte längre.",
+    "seat_source_not_title": "Noden är inte en titel som kan ha säte.",
+    "jarldom_missing_owner": "Jarldömet saknar angiven ägare.",
+    "unknown_owner_character": ("Den angivna ägarkaraktären finns inte längre."),
+    "unknown_owner_jarldom": "Jarldömet finns inte längre.",
+    "owner_key_not_jarldom": ("Ägarrelationen pekar inte på ett jarldöme."),
+}
+
+
+def _as_id(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return None
+
+
+def _get_node(world_data: Any, node_id: Any) -> Mapping[str, Any]:
+    if not isinstance(world_data, Mapping):
+        return {}
+    nodes = world_data.get("nodes")
+    if not isinstance(nodes, Mapping):
+        return {}
+    wanted_id = _as_id(node_id)
+    for raw_id, node in nodes.items():
+        candidate_id = _as_id(raw_id)
+        if candidate_id is None and isinstance(node, Mapping):
+            candidate_id = _as_id(node.get("node_id"))
+        if candidate_id == wanted_id and isinstance(node, Mapping):
+            return node
+    return {}
+
+
+def _format_target(
+    target_id: int,
+    label_callback: Callable[[int], str] | None,
+    fallback_kind: str,
+) -> str:
+    label = (
+        str(label_callback(target_id)).strip()
+        if label_callback is not None
+        else f"{fallback_kind} {target_id}"
+    )
+    if not label:
+        label = f"{fallback_kind} {target_id}"
+    if f"ID {target_id}" in label:
+        return label
+    return f"{label} (ID {target_id})"
+
+
+def _row(
+    key: str,
+    label: str,
+    target_id: int | None,
+    missing_value: str,
+    label_callback: Callable[[int], str] | None,
+    fallback_kind: str,
+) -> dict:
+    return {
+        "key": key,
+        "label": label,
+        "value": (
+            _format_target(target_id, label_callback, fallback_kind)
+            if target_id is not None
+            else missing_value
+        ),
+        "target_id": target_id,
+        "status": "ok" if target_id is not None else "missing",
+    }
+
+
+def _warning(issue: Any) -> dict:
+    code = getattr(issue, "code", "")
+    return {
+        "code": code,
+        "label": _WARNING_LABELS.get(code, "Okänt relationsproblem."),
+        "source_id": getattr(issue, "source_id", None),
+        "target_id": getattr(issue, "target_id", None),
+    }
+
+
+def _title_warnings(
+    world_data: Any, title_id: Any, seat_id: int | None
+) -> tuple[dict, ...]:
+    wanted_id = _as_id(title_id)
+    return tuple(
+        _warning(issue)
+        for issue in world_relations.validate_world_relations(world_data, strict=True)
+        if getattr(issue, "source_id", None) == wanted_id
+        or (
+            seat_id is not None
+            and getattr(issue, "target_id", None) == seat_id
+            and getattr(issue, "code", "").startswith(("seat_", "duplicate_title_seat"))
+        )
+    )
+
+
+def _jarldom_warnings(
+    world_data: Any, jarldom_id: Any, owner_id: int | None
+) -> tuple[dict, ...]:
+    wanted_id = _as_id(jarldom_id)
+    return tuple(
+        _warning(issue)
+        for issue in world_relations.validate_world_relations(world_data, strict=True)
+        if getattr(issue, "source_id", None) == wanted_id
+        or getattr(issue, "target_id", None) == wanted_id
+        or (
+            owner_id is not None
+            and getattr(issue, "target_id", None) == owner_id
+            and getattr(issue, "code", "") == "unknown_owner_character"
+        )
+    )
+
+
+def build_title_relations_presentation(
+    world_data: Any,
+    title_id: Any,
+    *,
+    get_node_label: Callable[[int], str] | None = None,
+) -> dict:
+    """Build read-only presentation data for a level 0-2 title node."""
+    seat_id = world_relations.get_title_seat(world_data, title_id)
+    return {
+        "title": "Relationer",
+        "rows": (
+            _row(
+                "title_seat",
+                "Titelns säte",
+                seat_id,
+                "Inget säte angivet",
+                get_node_label,
+                "Nod",
+            ),
+        ),
+        "warnings": _title_warnings(world_data, title_id, seat_id),
+    }
+
+
+def build_jarldom_relations_presentation(
+    world_data: Any,
+    jarldom_id: Any,
+    *,
+    get_node_label: Callable[[int], str] | None = None,
+    get_character_label: Callable[[int], str] | None = None,
+) -> dict:
+    """Build read-only presentation data for a level 3 jarldom node."""
+    node = _get_node(world_data, jarldom_id)
+    owner_id = world_relations.get_jarldom_owner(world_data, jarldom_id)
+    ruler_id = _as_id(node.get("ruler_id"))
+    anchor_id = _as_id(node.get("owner_assigned_id"))
+    seated_title_id = world_relations.get_seated_title(world_data, jarldom_id)
+    return {
+        "title": "Relationer",
+        "rows": (
+            _row(
+                "jarldom_owner",
+                "Jarldömets ägare",
+                owner_id,
+                "Ingen ägare angiven",
+                get_character_label,
+                "Karaktär",
+            ),
+            _row(
+                "ruler",
+                "Härskare",
+                ruler_id,
+                "Ingen härskare angiven",
+                get_character_label,
+                "Karaktär",
+            ),
+            _row(
+                "personal_province_anchor",
+                "Personlig provins / titelankare",
+                anchor_id,
+                "Lokal, inget titelankare",
+                get_node_label,
+                "Nod",
+            ),
+            _row(
+                "seat_for_title",
+                "Säte för titel",
+                seated_title_id,
+                "Inte säte för någon titel",
+                get_node_label,
+                "Nod",
+            ),
+        ),
+        "warnings": _jarldom_warnings(world_data, jarldom_id, owner_id),
+    }

--- a/tests/ui/test_world_relations_presentation.py
+++ b/tests/ui/test_world_relations_presentation.py
@@ -1,0 +1,278 @@
+"""Headless tests for world relation presentation helpers."""
+
+from copy import deepcopy
+
+import pytest
+
+from src import world_relations
+from src.ui import world_relations_presentation as presentation
+
+
+def world_data():
+    return {
+        "nodes": {
+            "1": {"node_id": 1, "parent_id": None},
+            "2": {"node_id": 2, "parent_id": 1},
+            "3": {"node_id": 3, "parent_id": 2},
+            "4": {
+                "node_id": 4,
+                "parent_id": 3,
+                "ruler_id": None,
+                "owner_assigned_id": None,
+            },
+            "5": {"node_id": 5, "parent_id": 3},
+        },
+        "characters": {"7": {"name": "Alva"}, "8": {"name": "Bo"}},
+    }
+
+
+def rows_by_key(result):
+    return {row["key"]: row for row in result["rows"]}
+
+
+def test_title_relation_presentation_uses_get_title_seat(monkeypatch):
+    data = world_data()
+    monkeypatch.setattr(presentation.world_relations, "get_title_seat", lambda *_: 4)
+    result = presentation.build_title_relations_presentation(
+        data, 1, get_node_label=lambda node_id: "Björkdalen"
+    )
+    assert rows_by_key(result)["title_seat"] == {
+        "key": "title_seat",
+        "label": "Titelns säte",
+        "value": "Björkdalen (ID 4)",
+        "target_id": 4,
+        "status": "ok",
+    }
+
+
+def test_title_relation_presentation_shows_missing_seat_text():
+    row = rows_by_key(presentation.build_title_relations_presentation(world_data(), 1))[
+        "title_seat"
+    ]
+    assert row["value"] == "Inget säte angivet"
+    assert row["status"] == "missing"
+
+
+def test_title_relation_presentation_does_not_use_personal_province_path():
+    data = world_data()
+    data["nodes"]["1"]["personal_province_path"] = [1, 2, 3, 4]
+    result = presentation.build_title_relations_presentation(data, 1)
+    assert rows_by_key(result)["title_seat"]["value"] == "Inget säte angivet"
+
+
+def test_title_relation_presentation_uses_node_label_callback():
+    data = world_data()
+    data["title_seats"] = {"1": "4"}
+    result = presentation.build_title_relations_presentation(
+        data, 1, get_node_label=lambda node_id: f"Säte {node_id}"
+    )
+    assert rows_by_key(result)["title_seat"]["value"] == "Säte 4 (ID 4)"
+
+
+def test_title_relation_presentation_falls_back_without_node_label_callback():
+    data = world_data()
+    data["title_seats"] = {"1": "4"}
+    result = presentation.build_title_relations_presentation(data, 1)
+    assert rows_by_key(result)["title_seat"]["value"] == "Nod 4 (ID 4)"
+
+
+def test_jarldom_relation_presentation_shows_explicit_owner():
+    data = world_data()
+    data["jarldom_owners"] = {"4": "7"}
+    result = presentation.build_jarldom_relations_presentation(data, 4)
+    row = rows_by_key(result)["jarldom_owner"]
+    assert row["label"] == "Jarldömets ägare"
+    assert row["target_id"] == 7
+
+
+def test_jarldom_relation_presentation_shows_missing_owner_text():
+    result = presentation.build_jarldom_relations_presentation(world_data(), 4)
+    assert rows_by_key(result)["jarldom_owner"]["value"] == "Ingen ägare angiven"
+
+
+def test_jarldom_relation_presentation_does_not_fallback_to_ruler():
+    data = world_data()
+    data["nodes"]["4"]["ruler_id"] = 8
+    result = presentation.build_jarldom_relations_presentation(data, 4)
+    rows = rows_by_key(result)
+    assert rows["jarldom_owner"]["value"] == "Ingen ägare angiven"
+    assert rows["ruler"]["value"] == "Karaktär 8 (ID 8)"
+
+
+def test_jarldom_relation_presentation_keeps_owner_and_ruler_separate():
+    data = world_data()
+    data["jarldom_owners"] = {"4": "7"}
+    data["nodes"]["4"]["ruler_id"] = 8
+    rows = rows_by_key(presentation.build_jarldom_relations_presentation(data, 4))
+    assert rows["jarldom_owner"]["target_id"] == 7
+    assert rows["ruler"]["target_id"] == 8
+
+
+def test_jarldom_relation_presentation_keeps_personal_anchor_separate():
+    data = world_data()
+    data["nodes"]["4"]["owner_assigned_id"] = 2
+    rows = rows_by_key(presentation.build_jarldom_relations_presentation(data, 4))
+    assert rows["personal_province_anchor"]["target_id"] == 2
+    assert rows["jarldom_owner"]["target_id"] is None
+
+
+def test_jarldom_relation_presentation_shows_seat_for_title():
+    data = world_data()
+    data["title_seats"] = {"1": "4"}
+    result = presentation.build_jarldom_relations_presentation(
+        data, 4, get_node_label=lambda node_id: "Nordriket"
+    )
+    assert rows_by_key(result)["seat_for_title"]["value"] == ("Nordriket (ID 1)")
+
+
+def test_jarldom_relation_presentation_shows_not_seat_text():
+    result = presentation.build_jarldom_relations_presentation(world_data(), 4)
+    assert rows_by_key(result)["seat_for_title"]["value"] == (
+        "Inte säte för någon titel"
+    )
+
+
+def test_jarldom_relation_presentation_uses_global_character_registry():
+    data = world_data()
+    data["characters"] = {}
+    data["nodes"]["4"]["characters"] = [{"id": 7, "name": "Lokal person"}]
+    data["jarldom_owners"] = {"4": "7"}
+    result = presentation.build_jarldom_relations_presentation(data, 4)
+    assert "Lokal person" not in rows_by_key(result)["jarldom_owner"]["value"]
+    assert result["warnings"][0]["code"] == "unknown_owner_character"
+
+
+def test_jarldom_relation_presentation_uses_character_label_callback():
+    data = world_data()
+    data["jarldom_owners"] = {"4": "7"}
+    result = presentation.build_jarldom_relations_presentation(
+        data, 4, get_character_label=lambda character_id: "Alva Silverhand"
+    )
+    assert rows_by_key(result)["jarldom_owner"]["value"] == ("Alva Silverhand (ID 7)")
+
+
+def test_jarldom_relation_presentation_falls_back_without_character_callback():
+    data = world_data()
+    data["jarldom_owners"] = {"4": "7"}
+    result = presentation.build_jarldom_relations_presentation(data, 4)
+    assert rows_by_key(result)["jarldom_owner"]["value"] == ("Karaktär 7 (ID 7)")
+
+
+@pytest.mark.parametrize(
+    ("builder", "node_id", "code", "expected"),
+    (
+        (
+            presentation.build_title_relations_presentation,
+            1,
+            "title_missing_seat",
+            "Titeln saknar angivet säte.",
+        ),
+        (
+            presentation.build_jarldom_relations_presentation,
+            4,
+            "jarldom_missing_owner",
+            "Jarldömet saknar angiven ägare.",
+        ),
+        (
+            presentation.build_title_relations_presentation,
+            1,
+            "duplicate_title_seat",
+            "Jarldömet används redan som säte för en annan titel.",
+        ),
+        (
+            presentation.build_title_relations_presentation,
+            1,
+            "seat_outside_title_subtree",
+            "Sätet ligger utanför titelns område.",
+        ),
+        (
+            presentation.build_jarldom_relations_presentation,
+            4,
+            "unknown_owner_character",
+            "Den angivna ägarkaraktären finns inte längre.",
+        ),
+    ),
+)
+def test_relation_presentation_maps_warnings(
+    monkeypatch, builder, node_id, code, expected
+):
+    issue = world_relations.RelationIssue(code, node_id, None)
+    monkeypatch.setattr(
+        presentation.world_relations,
+        "validate_world_relations",
+        lambda *_args, **_kw: [issue],
+    )
+    assert builder(world_data(), node_id)["warnings"][0]["label"] == expected
+
+
+def test_relation_presentation_maps_unknown_issue_code_to_neutral_warning(
+    monkeypatch,
+):
+    issue = world_relations.RelationIssue("future_issue", 1, None)
+    monkeypatch.setattr(
+        presentation.world_relations,
+        "validate_world_relations",
+        lambda *_args, **_kw: [issue],
+    )
+    result = presentation.build_title_relations_presentation(world_data(), 1)
+    assert result["warnings"][0]["label"] == "Okänt relationsproblem."
+
+
+def test_relation_presentation_does_not_mutate_world_data():
+    data = world_data()
+    expected = deepcopy(data)
+    presentation.build_title_relations_presentation(data, 1)
+    presentation.build_jarldom_relations_presentation(data, 4)
+    assert data == expected
+
+
+def test_relation_presentation_does_not_create_relation_indexes():
+    data = world_data()
+    presentation.build_title_relations_presentation(data, 1)
+    presentation.build_jarldom_relations_presentation(data, 4)
+    assert "title_seats" not in data
+    assert "jarldom_owners" not in data
+
+
+def test_relation_presentation_does_not_call_setters(monkeypatch):
+    def fail(*_args, **_kwargs):
+        raise AssertionError("A relation setter was called")
+
+    monkeypatch.setattr(presentation.world_relations, "set_title_seat", fail)
+    monkeypatch.setattr(presentation.world_relations, "clear_title_seat", fail)
+    monkeypatch.setattr(presentation.world_relations, "set_jarldom_owner", fail)
+    monkeypatch.setattr(presentation.world_relations, "clear_jarldom_owner", fail)
+    presentation.build_title_relations_presentation(world_data(), 1)
+    presentation.build_jarldom_relations_presentation(world_data(), 4)
+
+
+def test_relation_presentation_uses_required_swedish_labels():
+    title_result = presentation.build_title_relations_presentation(world_data(), 1)
+    jarldom_result = presentation.build_jarldom_relations_presentation(world_data(), 4)
+    labels = {
+        row["label"]
+        for result in (title_result, jarldom_result)
+        for row in result["rows"]
+    }
+    assert labels == {
+        "Jarldömets ägare",
+        "Titelns säte",
+        "Säte för titel",
+        "Personlig provins / titelankare",
+        "Härskare",
+    }
+
+
+def test_relation_presentation_does_not_use_ambiguous_owner_labels():
+    result = presentation.build_jarldom_relations_presentation(world_data(), 4)
+    labels = {row["label"] for row in result["rows"]}
+    assert labels.isdisjoint({"Ägare", "Ägande", "Ägarnoder", "Lokal ägo"})
+
+
+def test_relation_presentation_does_not_duplicate_callback_id():
+    data = world_data()
+    data["title_seats"] = {"1": "4"}
+    result = presentation.build_title_relations_presentation(
+        data, 1, get_node_label=lambda node_id: "Björkdalen (ID 4)"
+    )
+    assert rows_by_key(result)["title_seat"]["value"] == "Björkdalen (ID 4)"


### PR DESCRIPTION
### Motivation
- Provide a small, read-only presentation layer to show title seats and jarldom owners without touching UI widgets or mutating domain data.
- Keep domain concepts distinct (title seat, jarldom owner, personal province/title anchor, ruler, inverse seat) and expose stable Swedish labels and machine-readable warnings for the UI.
- Use only the public read-only `world_relations` API and make the helper fully testable headless.

### Description
- Added `src/ui/world_relations_presentation.py` with two public functions: `build_title_relations_presentation(world_data, title_id, *, get_node_label=None)` and `build_jarldom_relations_presentation(world_data, jarldom_id, *, get_node_label=None, get_character_label=None)` that return a dict presentation model (`"title"`, `"rows"` tuple of `{key,label,value,target_id,status}`, and `"warnings"` tuple of `{code,label,source_id,target_id}`).
- The helper queries relations only via `world_relations.get_title_seat`, `world_relations.get_seated_title`, `world_relations.get_jarldom_owner` and `world_relations.validate_world_relations` and never calls setters or reads `world_data["title_seats"]` / `world_data["jarldom_owners"]` directly.
- Implements Swedish labels and required missing-texts (`Inget säte angivet`, `Ingen ägare angiven`, `Inte säte för någon titel`, `Lokal, inget titelankare`, `Ingen härskare angiven`) and a mapping of relation issue codes to Swedish messages with a neutral fallback `Okänt relationsproblem.`.
- Formatting rules for callbacks: injected `get_node_label` / `get_character_label` are used when provided; stable fallbacks are `Nod <id>` / `Karaktär <id>` and the helper avoids duplicating `ID <id>` if the callback already includes it.

### Testing
- Added headless tests in `tests/ui/test_world_relations_presentation.py` that exercise callbacks, fallbacks, domain separation, warning mapping/filtering, and read-only guarantees; the file contains focused unit tests covering the specified scenarios.
- Ran targeted tests and full suite: the new UI tests passed and the full test suite completed successfully (headless focused tests and `pytest` run completed with all tests green on the execution environment used).
- Verified static checks and compilation: `python -m py_compile` on the new module and `black` formatting were applied and passed in checks.

Changed files:
- Added `src/ui/world_relations_presentation.py` (new read-only presentation helper).
- Added `tests/ui/test_world_relations_presentation.py` (headless tests).

Read-only / scope confirmations:
- The helper does not mutate `world_data`, does not create `title_seats`/`jarldom_owners`, does not call any setter/clear functions, and does not import or create any Tk widgets.
- `ruler_id` is presented only under the `Härskare` label and is never used as an implicit owner; `owner_assigned_id` is presented only under `Personlig provins / titelankare` and is never used as a jarldom owner; `personal_province_path` is not used as a title seat.
- All relation queries are performed via the public `world_relations` read-only API and warnings are gathered from `validate_world_relations(strict=True)` and filtered to the current node context.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30687526c4832eba64f671649a0512)