### PR TITLE
Render read-only world relations in node detail overviews

### DIFF
--- a/src/ui/views/node_details_view.py
+++ b/src/ui/views/node_details_view.py
@@ -12,6 +12,10 @@ from ui.storage_presentation import (
     build_reported_storage_overview,
 )
 from ui.strings import PANEL_NAMES, format_details_title
+from ui.world_relations_presentation import (
+    build_jarldom_relations_presentation,
+    build_title_relations_presentation,
+)
 from utils import ScrollableFrame
 
 
@@ -314,6 +318,56 @@ class NodeDetailsView:
                 side=tk.LEFT, padx=(6, 0)
             )
 
+    def _get_character_label(self, character_id: int) -> str:
+        characters = (self.app.world_data or {}).get("characters", {})
+        character = (
+            characters.get(str(character_id)) if isinstance(characters, dict) else None
+        )
+        if isinstance(character, dict):
+            name = str(character.get("name", "")).strip()
+            if name:
+                return name
+        return f"Karaktär {character_id}"
+
+    def _build_relations_presentation(self, node_id: int, depth: int) -> dict:
+        world_data = self.app.world_data or {}
+        if depth <= 2:
+            return build_title_relations_presentation(
+                world_data,
+                node_id,
+                get_node_label=self.app.get_display_name,
+            )
+        if depth == 3:
+            return build_jarldom_relations_presentation(
+                world_data,
+                node_id,
+                get_node_label=self.app.get_display_name,
+                get_character_label=self._get_character_label,
+            )
+        return {"title": "Relationer", "rows": (), "warnings": ()}
+
+    @classmethod
+    def _relation_rows_for_overview(
+        cls, presentation: dict
+    ) -> tuple[tuple[str, str], ...]:
+        rows = []
+        for row in presentation.get("rows", ()) or ():
+            if not isinstance(row, dict):
+                continue
+            rows.append((row.get("label", "Relation"), row.get("value", "")))
+        for warning in presentation.get("warnings", ()) or ():
+            if not isinstance(warning, dict):
+                continue
+            rows.append(("Varning", warning.get("label", "Okänt relationsproblem.")))
+        return tuple(rows)
+
+    def _add_relations_section(self, parent: tk.Misc, node_id: int, depth: int) -> None:
+        presentation = self._build_relations_presentation(node_id, depth)
+        rows = self._relation_rows_for_overview(presentation)
+        self._add_overview_section(
+            parent, presentation.get("title", "Relationer"), rows
+        )
+
     @staticmethod
     def _add_reported_storage_section(parent: tk.Misc, overview: dict) -> None:
         section = ttk.LabelFrame(parent, text=overview["title"], padding=10)
@@ -371,6 +425,7 @@ class NodeDetailsView:
                 ("Befolkning", population),
             ),
         )
+        self._add_relations_section(parent, node_id, depth)
         child_rows = [("Totalt", len(children))]
         child_rows.extend(sorted(child_types.items()))
         self._add_overview_section(parent, "Undernoder", child_rows)
@@ -428,6 +483,7 @@ class NodeDetailsView:
             for child_depth, count in sorted(child_depths.items())
         )
         self._add_overview_section(parent, "Sammanfattning", summary_rows)
+        self._add_relations_section(parent, node_id, depth)
 
         child_rows = []
         for child in children:

--- a/tests/ui/test_node_details_notebook.py
+++ b/tests/ui/test_node_details_notebook.py
@@ -1,3 +1,5 @@
+import copy
+import inspect
 import tkinter as tk
 from tkinter import ttk
 
@@ -822,3 +824,180 @@ def test_level_three_owner_dropdown_remains_outside_notebook(root):
     assert app.details_panel.ownership_frame.master is app.details_panel.body.master
     assert not _is_descendant(app.details_panel.ownership_frame, notebook)
     assert app.details_panel.ownership_combobox.instate(["readonly"])
+
+
+def _build_relations_world():
+    data = _build_world()
+    data["characters"] = {
+        "10": {"name": "Global ägare"},
+        "11": {"name": "Global härskare"},
+    }
+    data["nodes"]["2"]["children"] = [3, 4]
+    data["nodes"]["4"].update(
+        {
+            "parent_id": 2,
+            "children": [5],
+            "ruler_id": 11,
+            "owner_assigned_level": 2,
+            "owner_assigned_id": 2,
+            "personal_province_path": [2, 4],
+            "characters": [{"id": 10, "name": "Vilseledande lokal ägare"}],
+        }
+    )
+    data["title_seats"] = {"2": 4}
+    data["jarldom_owners"] = {"4": 10}
+    return data
+
+
+def _find_section(presentation_frame, title):
+    return next(
+        section
+        for section in _descendants_of_type(presentation_frame, ttk.LabelFrame)
+        if section.cget("text") == title
+    )
+
+
+def test_vassals_overview_renders_title_relations_in_existing_tab(root, monkeypatch):
+    app = ui_app.create_app(root)
+    app.world_data = _build_relations_world()
+    app.world_manager.set_world_data(app.world_data)
+
+    presentation_frame = _show_vassals_overview(app, monkeypatch, node_id=2)
+    texts = _descendant_texts(_find_section(presentation_frame, "Relationer"))
+
+    assert "Titelns säte:" in texts
+    assert any("ID 4" in text for text in texts)
+    assert "Vasaller & bidrag" in [
+        _find_notebook(app.details_panel.body).tab(tab_id, "text")
+        for tab_id in _find_notebook(app.details_panel.body).tabs()
+    ]
+
+
+def test_domain_overview_renders_jarldom_relations_in_existing_tab(root, monkeypatch):
+    app = ui_app.create_app(root)
+    app.world_data = _build_relations_world()
+    app.world_manager.set_world_data(app.world_data)
+
+    presentation_frame = _show_domain_overview(app, monkeypatch)
+    texts = _descendant_texts(_find_section(presentation_frame, "Relationer"))
+
+    assert {
+        "Jarldömets ägare:",
+        "Härskare:",
+        "Personlig provins / titelankare:",
+        "Säte för titel:",
+        "Global ägare (ID 10)",
+        "Global härskare (ID 11)",
+    }.issubset(texts)
+    assert any("ID 2" in text for text in texts)
+    assert "Domänöversikt" in [
+        _find_notebook(app.details_panel.body).tab(tab_id, "text")
+        for tab_id in _find_notebook(app.details_panel.body).tabs()
+    ]
+
+
+def test_relations_use_global_characters_not_ruler_or_anchor_as_owner(
+    root, monkeypatch
+):
+    app = ui_app.create_app(root)
+    app.world_data = _build_relations_world()
+    app.world_data["characters"]["2"] = {"name": "Fel ankarkaraktär"}
+    app.world_data["characters"]["11"] = {"name": "Fel ägare från härskare"}
+    app.world_manager.set_world_data(app.world_data)
+
+    texts = _descendant_texts(
+        _find_section(_show_domain_overview(app, monkeypatch), "Relationer")
+    )
+    owner_index = texts.index("Jarldömets ägare:") + 1
+
+    assert texts[owner_index] == "Global ägare (ID 10)"
+    assert "Vilseledande lokal ägare (ID 10)" not in texts
+    assert "Fel ägare från härskare (ID 11)" not in texts[owner_index]
+    assert "Fel ankarkaraktär (ID 2)" not in texts[owner_index]
+
+
+def test_relations_missing_values_and_warnings_render_without_mutation(
+    root, monkeypatch
+):
+    app = ui_app.create_app(root)
+    app.world_data = _build_world()
+    app.world_data["characters"] = {}
+    before = copy.deepcopy(app.world_data)
+    app.world_manager.set_world_data(app.world_data)
+
+    texts = _descendant_texts(
+        _find_section(_show_domain_overview(app, monkeypatch), "Relationer")
+    )
+
+    assert {
+        "Ingen ägare angiven",
+        "Ingen härskare angiven",
+        "Lokal, inget titelankare",
+        "Inte säte för någon titel",
+        "Varning:",
+        "Jarldömet saknar angiven ägare.",
+    }.issubset(texts)
+    assert app.world_data == before
+
+
+def test_relation_rendering_uses_helper_and_does_not_call_setters(monkeypatch):
+    calls = []
+
+    def fake_title(world_data, node_id, **kwargs):
+        calls.append((world_data, node_id, sorted(kwargs)))
+        return {
+            "title": "Relationer",
+            "rows": ({"label": "Titelns säte", "value": "Hjälparnod"},),
+            "warnings": ({"label": "Hjälparvarning"},),
+        }
+
+    monkeypatch.setattr(
+        node_details_view, "build_title_relations_presentation", fake_title
+    )
+    monkeypatch.setattr(
+        (
+            node_details_view.world_relations
+            if hasattr(node_details_view, "world_relations")
+            else node_details_view
+        ),
+        "set_title_seat",
+        lambda *args, **kwargs: pytest.fail("setter must not be called"),
+        raising=False,
+    )
+    view = object.__new__(NodeDetailsView)
+    view.app = type(
+        "AppStub",
+        (),
+        {
+            "world_data": {"nodes": {}},
+            "get_display_name": lambda self, node_id: f"Nod {node_id}",
+        },
+    )()
+
+    presentation = view._build_relations_presentation(2, 2)
+    rows = NodeDetailsView._relation_rows_for_overview(presentation)
+
+    assert calls == [({"nodes": {}}, 2, ["get_node_label"])]
+    assert rows == (("Titelns säte", "Hjälparnod"), ("Varning", "Hjälparvarning"))
+
+
+def test_level_three_owner_dropdown_label_and_position_remain_unchanged(root):
+    app = ui_app.create_app(root)
+    app.world_data = _build_relations_world()
+    app.world_manager.set_world_data(app.world_data)
+
+    app.show_node_view(app.world_data["nodes"]["4"])
+
+    assert app.details_panel.ownership_label.cget("text") == "Ägande:"
+    assert app.details_panel.ownership_combobox.instate(["readonly"])
+
+
+def test_node_details_view_does_not_call_relation_setters_or_read_maps_directly():
+    source = inspect.getsource(node_details_view.NodeDetailsView)
+
+    assert "set_title_seat" not in source
+    assert "clear_title_seat" not in source
+    assert "set_jarldom_owner" not in source
+    assert "clear_jarldom_owner" not in source
+    assert 'world_data["title_seats"]' not in source
+    assert 'world_data["jarldom_owners"]' not in source


### PR DESCRIPTION
### Motivation
- Expose the existing read-only world relations presentation in the node detail presentation tabs so relation rows and warnings are visible to users without adding any editing, dropdowns, setters or domain logic in the Tk layer. 
- Keep UI changes minimal and local to the node details renderer while reusing the already implemented presentation helpers.

### Description
- Wire `NodeDetailsView` to `ui.world_relations_presentation` by calling `build_title_relations_presentation` for depth 0–2 and `build_jarldom_relations_presentation` for depth 3, and render the returned `rows` and `warnings` as a new read-only section titled "Relationer". (changed file: `src/ui/views/node_details_view.py`).
- Added small adapter helpers inside `NodeDetailsView`: `_get_character_label`, `_build_relations_presentation`, `_relation_rows_for_overview`, and `_add_relations_section` to keep the change local and testable. Node labels are provided via `self.app.get_display_name` and character labels are looked up from global `world_data["characters"]` with a safe fallback. 
- Inserted the relations section into the existing overview tabs: after "Sammanfattning" in the "Vasaller & bidrag" view (depth 0–2) and in the "Domänöversikt" view (depth 3). 
- Added focused UI tests verifying that the correct labels appear in the correct tabs, warnings display, missing values render safely, global characters are used for owners, no setters or world-data maps are called directly from the view, and the legacy "Ägande:" dropdown remains unchanged (changed file: `tests/ui/test_node_details_notebook.py`).

### Testing
- Ran focused and full test suites and static checks; all required checks passed. 
- UI tests: `tests/ui/test_node_details_notebook.py` (new/updated tests) — 8 passed, 53 skipped (headless skips expected for Tk tests). 
- Helper/unit/domain tests: `tests/ui/test_world_relations_presentation.py` (27 passed), `tests/domain/test_world_relations.py` (68 passed), `tests/domain/test_personal_province.py` (15 passed). 
- Full test run: `pytest` — 454 passed, 115 skipped, 1 warning. `python -m py_compile` for changed modules and `black --check` succeeded, and repository grep checks confirmed no forbidden setter calls or direct reads of `title_seats`/`jarldom_owners` in the UI layer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a306fda3694832e976b61f86c4a70b9)