### PR TITLE
Add specifications-mode skill and initialize structured specs/ directory

### DIFF
--- a/.codex/skills/specifications-mode/SKILL.Changelog.md
+++ b/.codex/skills/specifications-mode/SKILL.Changelog.md
@@ -1,0 +1,14 @@
+# Changelog: Specifications Mode skill
+
+- 2026-07-15: Lade till direktiv om att changelog-filer ska vara omvänt kronologiska med nya poster överst.
+- 2026-07-13: Lade till arbetsflödet "Refresh specifications" för synkronisering av specs, git-historik vid oklarheter, omprövning av implementationplaner och destillering av utestående specifikationsfrågor.
+- 2026-07-09: Förtydligade att varje POC ska dokumentera hur erfarenheter återkopplas till beslut, hypotes-/planverifiering, levande specifikationer och samlingsöversikten.
+- 2026-07-08: Lade till policyn för separata `document.Changelog.md`-filer och regeln att changelog-filer inte ska läsas by default.
+- 2026-07-08: Lade till spec-lägesprototyping som avgränsat beslutsunderlag under `specs/prototyping/<poc-name>/`, med Python som rekommenderat POC-verktyg.
+- 2026-07-08: Förtydligade att POC:er i spec-läge ska ha verifierande testfall och regressionstester.
+- 2026-07-08: Lade till obligatorisk historikhänvisning sist i primärdokumentet.
+- 2026-07-08: Förtydligade att rekommenderade POC:er ska vara implementerbara under en session, sammanfattas i samlings-README och inte läsas by default.
+- 2026-07-08: Lade till att `.jrdl`-kontrakt kan användas för POC-kodgenerering via Alpha `jrdl2python` eller `jrdl2openrpc` och `openrpc-generator`, men att genererad kod inte ska checkas in.
+- 2026-07-08: Kompletterade skillen med en självbärande sammanfattning av JRDL-syntaxen från Alpha-specifikationen.
+- 2026-07-08: Uppdaterade JRDL-syntaxbeskrivningen: integer enumeration value documentation är vanlig metadata och ska inte beskrivas som reserverad för C-konstantnamn.
+- 2026-07-08: Återställde changelog-regeln till radformatet `- <YYYY-MM-DD>: <kommentar>` och förbjöd datumrubriker i changelog-filer.

--- a/.codex/skills/specifications-mode/SKILL.md
+++ b/.codex/skills/specifications-mode/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: specifications-mode
+description: Specification and prototype-support workflow for narrow product/domain specification work and spec-läge. Use when the user asks to arbeta med specifikationer, enter/leave spec-läge/spec mode, create or update business rules, verksamhetsbeskrivningar, requirements, implementation plans, priority groups, repo status, startup/introduktionsnivå, specstatus, sticky spec folders with domain subfolders, MCP-backed status tracking, or living product/domain specification documents; ask for confirmation only before actual repo-status changes; do not treat generic skill authoring or skill maintenance as specification work unless it describes the product/problem domain itself.
+---
+
+# Specifications Mode
+
+## Scope
+
+Specification work is intentionally narrow: it describes the problem domains, business/domain rules, product behavior, requirements, implementation plans, and decision-support prototypes for the idea/repo/product. Mechanical workflow documentation, such as creating or maintaining Codex skills, is not specification work by itself. Do not enter spec-läge only because the user asks to describe, write, or adjust a skill unless that work also creates or changes product/domain specifications.
+
+## Core rule
+
+When this skill is active and the repo is in **spec-läge**, create or edit only specification documents and clearly bounded decision-support prototypes under the sticky spec folder. Documentation files include `.md`, `.txt`, `.tex`, and other explicitly documentation-only formats. Prototype files are allowed only under `specs/prototyping/<poc-name>/` (or the repo's chosen spec folder equivalent) and only when they help resolve outstanding questions or provide decision evidence for specification work. Do not edit production source code, build files, generated program output, binaries, dependency files, or runtime application code while spec-läge is active.
+
+## Repo status and mode changes
+
+Always ask one explicit confirmation question before changing repo status when language suggests entering spec-läge, leaving spec-läge, or moving to implementation. Do not change durable specstatus until the user confirms. Suggested question: "Menar du att vi ska byta repo-status från `<current>` till `<target>`?"
+
+Do not ask the status-change confirmation question when the user's wording only points to the repo status that is already current. Treat that as a continuation inside the current mode, not as a proposed mode change. For example, if durable specstatus or the active conversation already says `SPEC` and the user asks to "fortsätta i spec-läge", "jobba med specifikationerna", or similar, continue the specification workflow directly instead of asking whether to switch into `SPEC` again. Likewise, if the repo is already in `IMPLEMENTATION` and the user asks to continue implementation, do not ask whether to switch to `IMPLEMENTATION` again.
+
+Track these repo statuses:
+
+- `NON_SPEC`: default work outside spec-läge, including skill authoring/maintenance and general documentation that does not describe product/domain specs.
+- `SPEC_PROPOSED`: language suggests spec-läge, but the user has not confirmed the status change yet.
+- `SPEC`: confirmed spec-läge; specification documents and bounded decision-support prototypes under `specs/prototyping/<poc-name>/` may be created or edited.
+- `IMPLEMENTATION_PROPOSED`: language suggests leaving spec-läge for implementation, but the user has not confirmed yet.
+- `IMPLEMENTATION`: confirmed implementation work; code/build changes may be allowed, while living specs should still be updated when implementation status changes.
+
+Mode rules:
+
+- Enter `SPEC` only after the user confirms product/domain specification work, requirements, verksamhetsbeskrivningar, regler, or implementation planning.
+- Leave `SPEC` only after the user confirms moving to implementation, coding, execution, or equivalent language.
+- Track state in the conversation first and keep a durable specstatus file in the sticky spec folder when one exists, for example `specs/status/SPECSTATUS.md`.
+- If the current mode is ambiguous, distinguish product/domain specification work from mechanical skill/tooling work. Use a proposed status and ask before switching.
+- If durable specstatus exists, use it as a direct hint for ambiguous follow-up questions such as "vad ska vi arbeta med härnäst?". When current status is `SPEC`, propose continuing with specification work by reviewing open questions, unresolved decisions, contradictions, or the next living spec. When current status is not `SPEC`, briefly summarize the likely next non-spec work from status/plans and ask whether the user wants to switch into specification work only if the requested task would require that switch.
+- Even after leaving spec-läge, keep living specification documents updated when implementation status changes.
+
+
+## Short requests for questions
+
+When the user asks a terse question such as "visa frågor", "frågor", "show questions", or equivalent, use current repo status and specstatus to resolve the ambiguity instead of asking what the word means.
+
+- If the repo is in `SPEC` or the status indicates active specification work, treat "questions" as specification questions: show a concise list of unresolved questions, open decisions, contradictions, ambiguities, unclear descriptions, and reasoning gaps from `specs/status/` and the living specification documents. Prefer existing open-question sections over inventing new questions.
+- If the repo has specstatus but is not currently doing specification work, still show a very short list of known open specification questions or likely unresolved specification areas, then ask whether the user wants to switch back to specification work before making documentation changes.
+- If no specstatus or specs exist, say that no durable specification question list exists yet and offer to scan the repo to create a first draft of specification questions. Do not create spec files until the user confirms the intended specification work/status when a status change would be required.
+
+## Specification files
+
+Prefer Markdown (`.md`) for specifications unless the user requests another documentation format. Keep specifications in one sticky folder for the repo. If no spec folder exists, choose a short clear name such as `specs/`, create it, and keep using that same folder for future specification work. Use subfolders for distinct domain areas to avoid a messy flat spec tree.
+
+Use at least these specification types and default subfolders:
+
+1. **Verksamhetsbeskrivningar och regler** in `specs/domains/`: business/domain descriptions, rules, constraints, glossary, and reasoning.
+2. **Implementationsplaner** in `specs/plans/`: prioritized implementation plans with action-level statuses. Keep plan history in the matching `document.Changelog.md` file.
+3. **Beslut (Decisions)** in `specs/decisions/`: durable decision records that state the chosen option, date, context, alternatives, consequences, and links to supporting evidence or affected plans. Use these when a choice should remain traceable after the conversation ends.
+4. **Underlag (Evidence)** in `specs/evidence/`: research notes, source summaries, observations, experiments, constraints, and other material that supports decisions or requirements without itself being the decision. Keep evidence factual and separate from conclusions.
+5. **Arkitektur** in `specs/architecture/`: architecture descriptions, system boundaries, component relationships, interfaces, quality attributes, and architectural constraints. Link to decisions and evidence when architecture choices depend on them.
+6. **Scheman (Schemas)** in `specs/schemas/`: data-bearing contracts that support specification work, for example JRDL schemas with pure JRDL types, XML schemas, JSON schemas, or other explicit contract formats. Keep schemas focused on contractual data shape, validation, and documentation metadata; put explanatory domain reasoning in `domains/`, decisions in `decisions/`, and architecture implications in `architecture/`.
+7. **Specstatus** in `specs/status/`: current mode, introduction level, living documents, and implementation status signals. Keep status history in the matching `document.Changelog.md` file.
+8. **Prototyping** in `specs/prototyping/`: disposable or exploratory proof-of-concept folders used only in spec-mode to answer open questions or support decisions. Each POC gets its own subfolder.
+9. **Temporära exportdokument** in `specs/tmp/`: generated, non-authoritative documents requested for short-term review, for example a `.tex` summary of open questions. These files must clearly state that they are temporary, volatile, and not governing specification sources.
+
+Additional types are allowed when useful, for example test strategy documents. Put each distinct domain area in its own subfolder when it grows beyond one focused document. Keep schemas, decisions, evidence, and architecture separate even when they refer to the same topic: schemas define data-bearing contracts, evidence supports, decisions choose, and architecture describes the resulting structure or constraints.
+
+## JRDL schema syntax for specifications and POCs
+
+JRDL (`.jrdl`) is our JSON-RPC Definition Language for data-model and operation contracts. A JRDL file can define reusable data types, JSON-RPC calls, imports, and transport metadata. Keep JRDL in `specs/schemas/` when it is part of our living specification, and treat it as hand-written source.
+
+Native scalar types are `string`, `integer`, `boolean`, and `float`. Extended definitions are `enumeration`, `set`, `dictionary`, and `object`; these can be referenced by object members, call parameters, return values, dictionaries, and other objects.
+
+Members, parameters, and returns may have an optional `min max` cardinality pair. Omitted cardinality means mandatory single value (`1 1`); `0 1` means optional single value; `0 -1` means optional unbounded array; and values such as `0 40` mean optional arrays with an upper bound. Arrays use the same type names as scalar values. A member array can be declared as a named array by adding `named` after the cardinality, for example `member "tags" "string" 0 -1 named`, which represents an object whose values all have the declared item type.
+
+Use these core JRDL forms:
+
+```jrdl
+enumeration <name> <"integer"|"string">
+	value <value> [documentation <text>]
+
+set <name>
+	value <value>
+
+dictionary <name> <type|extended type>
+
+object <name> [extends <object>] [documentation <text>]
+	member <name> <type|extended type> [min max [named]] [validation <regexp>] [documentation <text>]
+
+call <name> [documentation <text>]
+	parameter <name> <type|extended type> [min max] [validation <regexp>] [documentation <text>]
+	return <name> <type|extended type> [min max] [validation <regexp>] [documentation <text>]
+```
+
+Enumeration base types are `integer` or `string`. Enumeration values may carry ordinary `documentation <text>` metadata for both integer and string enumerations; do not reserve integer-enum documentation for generated C-style constant names unless a specific downstream generator contract explicitly requires that. A `set` is always integer-backed; each declared value is represented as one bit. A `dictionary` is represented as a JSON object with string keys and values of the declared type. An `object` can extend another object and can use `validation <regexp>` and `documentation <text>` on members. Call parameters and returns use the same cardinality, validation, and documentation style as members.
+
+Operation files can declare metadata before calls:
+
+```jrdl
+jsonrpc "2.0"
+protocol "line"
+url "http://localhost:1080/my/service"
+is-array "false"
+```
+
+`jsonrpc` declares the JSON-RPC version, `protocol` declares transport such as `line` or `http`, `url` declares the HTTP path or endpoint, and `is-array` controls whether generated client code sends JSON-RPC `params` as an array instead of an object.
+
+JRDL supports imports with prefixes for local files, relative files, and URL-based schemas:
+
+```jrdl
+import "types.jrdl" with prefix "s0"
+import "../other_types/types.jrdl" with prefix "s1"
+
+call "GetPersonInfo"
+	parameter "extra_info" "s1:ExtraInfo" 0 1
+	return "person" "s0:Person"
+```
+
+Use prefixed references such as `s0:Person` when referring to imported types. Keep imported schemas explicit and local when possible so POCs remain reproducible.
+
+## Specification prototyping
+
+Prototyping is allowed as part of specification work only while the repo is in confirmed `SPEC` mode. A prototype must be a bounded proof of concept that helps resolve outstanding questions, compare alternatives, validate assumptions, or create decision evidence. A recommended POC must be small enough to implement within one working session. It must not become production implementation by stealth.
+
+Place every POC in its own folder under the sticky spec folder's `prototyping/` directory, for example `specs/prototyping/coverage-formula-poc/`. Keep any notes, input data, scripts, and outputs for that POC inside its folder unless the user explicitly chooses another spec-folder structure. Summarize every created POC in the collection README, for example `specs/prototyping/README.md`, with status `OPEN` or `FINISHED`.
+
+Recommend prototyping to the user when a small one-session experiment can provide fast guidance for continued spec work, especially for formulas, data-shape validation, UI flow sketches, generator/balance assumptions, migration/recovery rules, or ambiguity that would otherwise lead to speculative implementation planning.
+
+Prefer Python for POCs because it is quick to write, inspect, and discard, but allow other languages or tools when they fit the question better. Keep dependencies minimal and documented in the POC folder.
+
+When a POC uses our data-model contracts (`.jrdl`), treat the JRDL files as the authoritative contract input rather than as generated output. These contracts can be used with Alpha's `jrdl2python` to generate Python models for the POC, and they can also be used through `jrdl2openrpc` followed by `openrpc-generator` to generate bindings or clients in any needed target language. Do not commit generated code in POC folders. Instead, make code generation an explicit first step in the POC build and run workflow so generated models or language bindings are recreated locally before building, testing, or running the POC.
+
+Every POC must include verifying test cases and regression tests that can be rerun to prove the observed behavior stays stable while the specification question is being evaluated. These tests can be lightweight, but they must document expected outcomes and fail visibly when the POC no longer supports its stated conclusion.
+
+Every POC must also document how its experience feeds back into the rest of the specifications. At minimum, the POC README should state whether the POC is intended as decision evidence, hypothesis/plan verification, risk discovery, or rejected exploration, and it should link to the affected questions, decisions, schemas, domain rules, architecture notes, evidence notes, or implementation-plan actions. When a POC changes the recommended direction, update the relevant living specifications or create a decision/evidence document in the same change; if the POC is still only indicative, keep the affected question open and state what remains unresolved. The collection README should summarize this feedback status so future work can see whether each POC has already influenced decisions, plans, schemas, or only remains candidate evidence.
+
+Do not read existing POC folders by default. Read a POC only when the current specification task explicitly needs that prototype, when its summary in the collection README indicates relevant evidence, or when the user asks for prototype history/details. Prefer the collection README summary first.
+
+Do not create or extend spec-mode POCs when the repo is in `NON_SPEC`, `IMPLEMENTATION_PROPOSED`, or `IMPLEMENTATION`; ask for or confirm the appropriate status first when needed.
+
+## Document changelogs
+
+Keep changelog/history sections out of ordinary specification documents. For every Markdown document that needs history, create or update a sibling changelog file named `document.Changelog.md`, where `document.md` becomes `document.Changelog.md`. Examples: `item-engine.md` -> `item-engine.Changelog.md`, `SPECSTATUS.md` -> `SPECSTATUS.Changelog.md`, and `SKILL.md` -> `SKILL.Changelog.md`.
+
+Do not read `*.Changelog.md` files by default. Read them only when specification work requires historical investigation, audit context, status reconstruction, or explicit user-requested history. Current-state work should rely on the non-changelog specification documents first.
+
+When updating a document and its history matters, add one changelog row to the matching `*.Changelog.md` file using the exact format `- <YYYY-MM-DD>: <comment>`. Changelog files are reverse chronological: put new entries at the top, directly under the title or any fixed introductory text, so the newest change is easiest to find. Do not use date subheadings such as `## <YYYY-MM-DD>` inside changelog files, and do not add a `## Changelog`, `## Senaste lägesändringar`, or similar history section to the primary document. Keep only the mandatory final history-reference footer in the primary document.
+
+## History reference footer
+
+Every primary specification Markdown document must end with a final `## Historik` section whose final bullet points to the matching changelog file when it exists. Example bullet: `- Ändringshistorik finns i document.Changelog.md.` If the changelog file does not exist yet, the final bullet must instead say that changes will be saved in the corresponding file. Example bullet: `- Ändringar kommer att sparas i document.Changelog.md.`
+
+Keep this footer as the last content in the primary document so readers can find history without loading it by default. Do not put actual changelog entries in the footer; entries belong only in the matching `*.Changelog.md` file.
+
+## Startup/introduction level
+
+At session start or before first spec change, classify the repo's startup/introduction level and record it in specstatus when a status file exists:
+
+- `NONE`: no specs exist. Propose analyzing/scanning source code to build preliminary verksamhetsbeskrivningar before creating draft specs.
+- `UNSTRUCTURED`: specs or documents exist but lack structure. Propose organizing them into sticky folders such as `specs/domains/`, `specs/plans/`, and `specs/status/` before adding much new content.
+- `STRUCTURED`: sticky spec folder and clear subfolders exist. Continue updating existing living documents and statuses.
+
+## MCP coordination
+
+If MCP support is available in the current session, use it as a source of truth or synchronization aid for at least implementation priority, actions, and status. Prefer MCP resources/templates over ad-hoc inference when they expose project planning data. Reflect relevant MCP-backed status changes in implementation plans and specstatus without exposing sensitive data unnecessarily.
+
+## Business descriptions and rules
+
+For verksamhetsbeskrivningar, regularly review for:
+
+- direct contradictions
+- ambiguity or terms with multiple possible meanings
+- unclear descriptions
+- direct gaps in reasoning or missing prerequisites
+
+A review is not required after every edit, but perform one periodically, whenever the user asks, or before using the document as the basis for implementation. Record review results in the relevant document or in a companion status section. Regularly compress documentation text to reduce future agent context cost, but preserve meaning, traceability, and enough detail for implementation.
+
+## Refresh specifications
+
+When the user asks to refresh, synchronize, reconcile, or realign specifications, treat the request as a full specification refresh of the sticky spec folder. The goal is to make the living specification set internally consistent, decision-aware, and ready for the next round of planning without silently turning unresolved specification questions into implementation assumptions.
+
+Refresh workflow:
+
+1. Identify the sticky spec folder, current specstatus, living domain documents, architecture notes, schemas, decision records, evidence notes, implementation plans, and existing open-question or outstanding-question documents. Prefer current primary documents first; read `*.Changelog.md` files only when history is needed to resolve ambiguity or reconstruct why a statement changed.
+2. Synchronize related specification documents. When new information appears in only one place, propagate the meaning to other documents that discuss the same rule, term, decision, schema, architecture constraint, plan dependency, or open question. Preserve each document type's responsibility: domain/rule documents explain behavior and terms, schemas define data contracts, decisions record choices, evidence records support, architecture records structure and constraints, plans record execution order, and status documents record current state.
+3. Detect contradictions, stale statements, duplicate wording with diverging meaning, missing links between decisions and affected documents, and terminology drift. Resolve straightforward inconsistencies directly when the governing decision or newer source is clear. When the correct resolution is not clear, keep both sides traceable and convert the conflict into an explicit outstanding specification question instead of guessing.
+4. Use git history when chronology matters. If current documents conflict or a statement's intended ordering is ambiguous, inspect relevant commits with commands such as `git log -- <path>`, `git show <commit> -- <path>`, or `git blame <path>` to reconstruct the timeline. Use that timeline as decision evidence, not as automatic authority: a newer change may still be wrong if it contradicts a durable decision.
+5. Re-evaluate implementation plans after specifications and decisions are coherent. Rethink the plan from the refreshed specification/decision state and what is best for the product now, not merely by preserving the previous task order. Update priorities, blockers, statuses, and superseded actions as needed; append the required changelog entry for plan changes.
+6. Finally, update or create `specs/status/outstanding-questions.md` unless the repo has clearly chosen another outstanding-question location. Distill the most important remaining **specification** work, including unresolved decisions, contradictions, unclear terms, missing evidence, and questions that block or materially affect implementation planning. Keep it focused: do not use it as a general coding backlog.
+
+During a refresh, do not create production implementation work. If the repo is not already in confirmed `SPEC` mode and the refresh would require editing specification documents, follow the normal repo status confirmation rules before making durable specification changes.
+
+## Open questions before implementation planning
+
+Before creating or maintaining an implementation plan, review the relevant specification status and living spec documents for unresolved questions, open decisions, contradictions, ambiguities, unclear descriptions, reasoning gaps, and other unresolved items that would make implementation planning speculative. If any such question marks exist, the skill recommendation is to resolve or decide them first instead of creating or updating the implementation plan.
+
+The user may still explicitly request that the implementation plan be created or updated despite unresolved question marks. In that case, proceed only with the requested plan work, make the unresolved items visible as blockers or risks in the plan, and keep recommending that all question marks be straightened out before implementation starts.
+
+## Temporary open-question `.tex` export
+
+When the user requests a generated `.tex` document with open questions, create a temporary, non-governing export that summarizes everything under `specs/` that still needs to be resolved or decided according to current specstatus and the living specification documents. Place it under `specs/tmp/` using a clear name such as `open-questions-YYYY-MM-DD.tex` so its path signals that it is temporary and volatile.
+
+The export must clearly state inside the document that it is generated, temporary, volatile, and not a governing source of truth. It must point readers back to the durable source documents under `specs/status/`, `specs/domains/`, `specs/decisions/`, `specs/evidence/`, `specs/architecture/`, `specs/schemas/`, and `specs/plans/` as applicable. Do not treat the temporary `.tex` export as a replacement for resolving the underlying questions in the durable specs.
+
+## Implementation plans
+
+Implementation plans must contain:
+
+- priority groups, for example `P0`, `P1`, `P2`, or named groups
+- prioritized actions within each group
+- one status per action
+- a matching `document.Changelog.md` file with dates and what changed
+
+Recommended action statuses:
+
+- `OPEN`: planned and not started
+- `IN_PROGRESS`: currently being worked on
+- `RESOLVED`: completed and reflected in implementation or documentation
+- `BLOCKED`: cannot proceed until a blocker is removed
+- `DEFERRED`: intentionally postponed
+- `SUPERSEDED`: replaced by another action or decision
+
+Use ISO dates (`YYYY-MM-DD`) in `*.Changelog.md` entries.
+
+## Working workflow
+
+1. Announce the mode when entering or leaving spec-läge.
+2. Confirm that planned edits are limited to specification documents and/or bounded POCs under `specs/prototyping/<poc-name>/` while in spec-läge.
+3. Create or update the relevant `.md`, `.txt`, or `.tex` files, and ensure primary specification Markdown documents end with the required history-reference footer.
+4. For business/rule docs, add review notes when contradictions, ambiguities, unclear descriptions, or reasoning gaps are found.
+5. Before creating or maintaining implementation plans, check for unresolved question marks and recommend resolving them first; recommend a one-session POC with verifying test cases and regression tests when it can quickly clarify a question or provide decision evidence, unless the user explicitly asks to update the plan anyway.
+6. For implementation plans, update action statuses in the plan and append history entries to the matching `*.Changelog.md` file whenever priorities or statuses change.
+7. Compress overly long documentation sections when they can be shortened without making the text unclear. Lagom is best: reduce repetition and obsolete detail, not necessary context.
+8. If implementation work later resolves or blocks plan items, update the living specification documents as part of the same work.
+
+## Templates
+
+Use `references/spec-templates.md` for concise templates for business/rule specifications, implementation plans, and specification status files.
+
+## Historik
+- Ändringshistorik finns i `SKILL.Changelog.md`.

--- a/.codex/skills/specifications-mode/agents/openai.yaml
+++ b/.codex/skills/specifications-mode/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Specifications Mode"
+  short_description: "Work safely in documentation-only specification mode."
+  default_prompt: "Arbeta med specifikationer i spec-läge."

--- a/.codex/skills/specifications-mode/references/spec-templates.Changelog.md
+++ b/.codex/skills/specifications-mode/references/spec-templates.Changelog.md
@@ -1,0 +1,8 @@
+# Changelog: Specifications Mode templates
+
+- 2026-07-08: Tog bort inbyggda changelog-sektioner från mallarna och lade till en mall för separat changelog-fil.
+- 2026-07-08: Lade till mallstöd för POC-mappar under `specs/prototyping/`.
+- 2026-07-08: Lade till verifierande testfall och regressionstäckning i POC-mallen.
+- 2026-07-08: Lade till obligatorisk historikhänvisning sist i primärdokumentet.
+- 2026-07-08: Lade till samlings-README-mall för POC-status `OPEN`/`FINISHED` och sessionsstorleksregel.
+- 2026-07-08: Bekräftade att separat historikfil använder radformatet `- <YYYY-MM-DD>: <Change.>`.

--- a/.codex/skills/specifications-mode/references/spec-templates.md
+++ b/.codex/skills/specifications-mode/references/spec-templates.md
@@ -1,0 +1,322 @@
+# Specifications Mode Templates
+
+## Verksamhetsbeskrivning och regler
+
+```md
+# <Topic>: Verksamhetsbeskrivning och regler
+
+## Syfte
+- <Why this domain/rule set exists.>
+
+## Begrepp
+- **<Term>**: <Definition.>
+
+## Regler
+1. <Rule.>
+2. <Rule.>
+
+## Resonemang och antaganden
+- <Assumption or rationale.>
+
+## Öppna frågor
+- [ ] <Question.>
+
+## Kvalitetskontroll
+Senast kontrollerad: <YYYY-MM-DD>
+
+### Motsägelser
+- <None found / finding.>
+
+### Tvetydigheter
+- <None found / finding.>
+
+### Otydliga beskrivningar
+- <None found / finding.>
+
+### Glapp i resonemang
+- <None found / finding.>
+
+```
+
+## Implementationsplan
+
+Skapa eller underhåll normalt inte en implementationsplan när öppna frågor, öppna beslut, motsägelser, tvetydigheter, otydliga beskrivningar eller resonemangsglapp fortfarande behöver lösas. Om brukaren uttryckligen begär planuppdatering ändå, synliggör dessa punkter som blockers eller risker.
+
+```md
+# <Topic>: Implementationsplan
+
+## Mål
+- <Target outcome.>
+
+## Statusöversikt
+- Total status: <OPEN | IN_PROGRESS | RESOLVED | BLOCKED | DEFERRED>
+- Senast uppdaterad: <YYYY-MM-DD>
+
+## Prioritetsgrupper
+
+### P0 - <Name>
+1. [OPEN] <Action id/title>
+   - Beskrivning: <Action details.>
+   - Blocker: <None / blocker.>
+   - Kopplad specifikation: <Link or path.>
+
+### P1 - <Name>
+1. [OPEN] <Action id/title>
+   - Beskrivning: <Action details.>
+   - Blocker: <None / blocker.>
+   - Kopplad specifikation: <Link or path.>
+
+```
+
+## Sticky spec folder README
+
+```md
+# Specifikationer
+
+Den här mappen är repots sticky plats för specifikationer. Fortsätt använda den för verksamhetsbeskrivningar, regler, implementationsplaner och specstatus.
+
+## Dokument
+- `domains/`: verksamhetsbeskrivningar och regler per domänområde.
+- `plans/`: implementationsplaner, prioriteringar, åtgärder och status.
+- `decisions/`: beslut med valt alternativ, kontext, alternativ, konsekvenser och länkat underlag.
+- `evidence/`: underlag, källor, observationer, experiment och fakta som stödjer krav eller beslut.
+- `architecture/`: arkitektur, systemgränser, komponentrelationer, gränssnitt och kvalitetsattribut.
+- `schemas/`: databärande kontrakt som stödjer specifikationsarbete, till exempel JRDL-schema med rena JRDL-typer, XML-schema, JSON-schema eller andra explicita kontraktsformat.
+- `status/SPECSTATUS.md`: aktuell specstatus och levande dokument.
+- `prototyping/`: avgränsade POC-mappar som bara används i spec-läge för att lösa frågor eller skapa beslutsunderlag; samlings-README listar POC:er med status `OPEN` eller `FINISHED`.
+- `tmp/`: temporära, genererade exportdokument utan styrande funktion, till exempel öppna frågor i `.tex`.
+
+## Introduktionsnivå
+- `NONE`: föreslå källkodsscanning för preliminära verksamhetsbeskrivningar.
+- `UNSTRUCTURED`: föreslå strukturering av befintliga dokument.
+- `STRUCTURED`: fortsätt underhålla levande dokument.
+
+## Principer
+- Specifikationer gäller produktens/problemets domän, inte mekaniska handgrepp som skill-författande.
+- Använd undermappar för tydliga domänområden.
+- Håll dokumentationen tillräckligt kort för att spara agent-bränsle.
+- Bevara tydlighet, beslut och status även när text komprimeras.
+- Rekommendera prototyping när ett litet experiment kan ge snabb vägledning för fortsatt specifikationsarbete.
+```
+## Schema / databärande kontrakt
+
+Använd för kontrakt som specificerar dataform, validering och dokumentationsmetadata. Håll domänresonemang i `domains/`, beslut i `decisions/` och arkitekturkonsekvenser i `architecture/`.
+
+````md
+# <Topic>: Schema
+
+## Syfte
+- <Vilket kontrakt schemat definierar och vilka specifikationer det stödjer.>
+
+## Format
+- Typ: <JRDL | XML Schema | JSON Schema | other>
+- Fil(er): <Path(s) to schema files or embedded contract.>
+
+## Kontraktsregler
+- <Rule about allowed types, documentation metadata, validation, versioning, etc.>
+
+## Schema
+```<format>
+<Schema excerpt or full schema if it is concise enough.>
+```
+
+## Stödjer
+- Domänspecifikationer: <Path/link or none.>
+- Beslut: <Path/link or none.>
+- Planer: <Path/link or none.>
+
+````
+
+## Spec-läge status
+
+```md
+# Specifikationsstatus
+
+- Sticky specmapp: `specs/`
+- Repostatus: <NON_SPEC | SPEC_PROPOSED | SPEC | IMPLEMENTATION_PROPOSED | IMPLEMENTATION>
+- Uppstartsnivå: <NONE | UNSTRUCTURED | STRUCTURED>
+- Senast uppdaterad: <YYYY-MM-DD>
+
+## Levande dokument
+- `<path>`: <type>, <current status>, <notes.>
+
+## MCP-stöd
+- Tillgängligt: <yes | no | unknown>
+- Källa för prioritering/åtgärder/status: <resource/tool or none>
+
+
+## Väntar på bekräftelse
+- Föreslaget byte: <none | current -> target>
+- Fråga ställd: <yes | no>
+
+```
+
+
+## Beslut (Decision record)
+
+```md
+# <Topic>: Beslut
+
+- Datum: <YYYY-MM-DD>
+- Status: <PROPOSED | ACCEPTED | SUPERSEDED | REJECTED>
+- Beslut: <Chosen option.>
+
+## Kontext
+- <Problem, constraints, and why a decision is needed.>
+
+## Alternativ
+1. <Option and tradeoff.>
+2. <Option and tradeoff.>
+
+## Konsekvenser
+- Positivt: <Expected benefit.>
+- Negativt/risk: <Known cost or risk.>
+
+## Underlag
+- <Path/link to evidence.>
+
+## Påverkar
+- Planer: <Path/link or none.>
+- Arkitektur: <Path/link or none.>
+
+```
+
+## Underlag (Evidence)
+
+```md
+# <Topic>: Underlag
+
+## Syfte
+- <What question this evidence helps answer.>
+
+## Källor och observationer
+- <Source/observation/experiment and date.>
+
+## Tolkning och begränsningar
+- <What can and cannot be concluded.>
+
+## Stödjer
+- Krav: <Path/link or none.>
+- Beslut: <Path/link or none.>
+
+```
+
+## Arkitektur
+
+```md
+# <Topic>: Arkitektur
+
+## Syfte och omfattning
+- <Architecture area and boundaries.>
+
+## Systemgränser och komponenter
+- <Components, responsibilities, and relationships.>
+
+## Gränssnitt och dataflöden
+- <Interfaces, contracts, or flows.>
+
+## Kvalitetsattribut och constraints
+- <Performance, determinism, maintainability, portability, etc.>
+
+## Kopplade beslut och underlag
+- Beslut: <Path/link or none.>
+- Underlag: <Path/link or none.>
+
+```
+
+
+## Prototyping samlings-README
+
+```md
+## POC:er
+Statusvärden: `OPEN`, `FINISHED`.
+
+| POC | Status | Fråga | Senaste resultat |
+| --- | --- | --- | --- |
+| `<poc-name>/` | OPEN | <question> | <short result or pending> |
+```
+
+## Prototyping-POC
+
+Skapa en egen undermapp under `specs/prototyping/<poc-name>/` för varje POC. En rekommenderad POC ska vara så liten att den kan implementeras under en session. Python rekommenderas, men välj fritt verktyg när frågan tjänar på det. Varje POC ska ha verifierande testfall och regressionstester som kan köras om. Sammanfatta POC:en i `specs/prototyping/README.md` med status `OPEN` eller `FINISHED`.
+
+```md
+# <POC name>
+
+## Fråga
+- <Vilken utestående fråga eller vilket beslut POC:en ska stödja.>
+
+## Hypotes / alternativ
+- <Vad vi testar eller jämför.>
+
+## Körning
+- Kommando: `<command>`
+- Beroenden: <none / dependencies>
+
+## Verifierande testfall och regression
+- Testkommando: `<test command>`
+- Förväntat resultat: <expected result>
+- Regressionstäckning: <Vilket beteende/resultat testet låser.>
+
+## Resultat
+- <Kort observation.>
+
+## Rekommendation
+- <Hur resultatet bör påverka specifikationen eller beslutet.>
+```
+
+
+## Obligatorisk historikhänvisning sist i varje spec-dokument
+
+Lägg sist i primära spec-dokument. Om changelog-filen finns, använd första raden. Om filen ännu saknas, använd andra raden tills filen skapas.
+
+```md
+## Historik
+- Ändringshistorik finns i `<Document name>.Changelog.md`.
+```
+
+```md
+## Historik
+- Ändringar kommer att sparas i `<Document name>.Changelog.md`.
+```
+
+
+## Separat historikfil
+
+Skapa bara när historik behövs för motsvarande Markdown-dokument. Läs inte dessa filer by default; använd dem vid historikutredning, statusrekonstruktion eller explicit fråga om historik.
+
+```md
+# <Document title>: historik
+
+- <YYYY-MM-DD>: <Change.>
+```
+
+
+## Temporär `.tex`-export av öppna frågor
+
+```tex
+\documentclass[a4paper,11pt]{article}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage[swedish]{babel}
+\usepackage[a4paper,margin=28mm]{geometry}
+\title{Temporär export: öppna frågor}
+\date{<YYYY-MM-DD>}
+\begin{document}
+\maketitle
+\textbf{Detta dokument är genererat, temporärt och flyktigt. Det är inte styrande och ersätter inte källdokumenten under specs/.}
+
+\section*{Källor}
+\begin{itemize}
+  \item <specs/status/SPECSTATUS.md eller annat källdokument>
+\end{itemize}
+
+\section*{Öppna frågor och beslut}
+\begin{itemize}
+  \item <Fråga/beslut som behöver lösas, med källdokument.>
+\end{itemize}
+\end{document}
+```
+
+## Historik
+- Ändringshistorik finns i `spec-templates.Changelog.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,17 @@ Notes
 - Install dependencies with `pip install -r requirements.txt` before running tests.
 - Run the test suite from the repository root with `pytest` (e.g., `pytest --cov`).
 
+Skills
+------
+
+- Use the repository skill in `.codex/skills/specifications-mode/` for product
+  and domain specification work. Read its `SKILL.md` before creating or
+  updating specifications.
+
+Specifications
+--------------
+
+- Living specifications are under `specs/`; begin with `specs/README.md` and
+  use `specs/status/SPECSTATUS.md` for the current specification status.
+- `README.vision` is retired and retained only as reference material. Do not
+  update it as a living specification; transfer confirmed changes to `specs/`.

--- a/README.vision
+++ b/README.vision
@@ -1,3 +1,10 @@
+RETIRED - REFERENSMATERIAL
+==========================
+
+Detta dokument är en tidigare specifikation och är endast referensmaterial.
+Levande specifikationer finns i `specs/`. Innehållet här ska inte uppdateras
+som styrande krav.
+
 En vision - Punktlista
 ======================
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,34 @@
+# Specifikationer
+
+Det här är repots fasta plats för levande produkt- och domänspecifikationer.
+Dokumenten utgår från befintligt beteende och det tidigare visionsdokumentet,
+men skiljer bekräftade nulägeskrav från framtida idéer.
+
+## Dokument
+
+- `domains/simulation.md`: verksamhetsbeskrivning, begrepp och regler.
+- `architecture/system-overview.md`: systemgränser och huvudkomponenter.
+- `plans/product-plan.md`: prioriterade specifikations- och införandeåtgärder.
+- `status/SPECSTATUS.md`: aktuell repostatus, öppna frågor och levande dokument.
+- `decisions/`: framtida spårbara produkt- och arkitekturbeslut.
+- `evidence/source-inventory.md`: underlag och härledning från tidigare material.
+- `schemas/`: framtida databärande kontrakt; inga befintliga scheman ändras här.
+- `prototyping/`: avgränsade POC:er som endast får skapas i bekräftat spec-läge.
+- `tmp/`: temporära, icke-styrande exporter.
+
+## Tidigare specifikationer
+
+- `README.vision` är **retired** och bevaras som **referensmaterial**.
+- Produktbeskrivningar i `README.md` är användar- och utvecklardokumentation,
+  inte styrande specifikation. De har använts som nulägesunderlag.
+
+## Arbetssätt
+
+- Följ `.codex/skills/specifications-mode/SKILL.md`.
+- Lägg domänregler, planer, beslut, underlag och arkitektur i respektive mapp.
+- Lös öppna frågor innan blockerade planåtgärder flyttas till implementation.
+- Ändra inte produktionskod medan repostatus är `SPEC`.
+
+## Historik
+
+- Ändringar kommer att sparas i `README.Changelog.md`.

--- a/specs/architecture/system-overview.md
+++ b/specs/architecture/system-overview.md
@@ -1,0 +1,46 @@
+# Systemöversikt: arkitektur
+
+## Syfte och omfattning
+
+Dokumentet beskriver nuvarande huvudgränser utan att föreskriva ändringar i
+server, datakontrakt, `world_manager` eller admin-läge.
+
+## Systemgränser och komponenter
+
+- `src/Feudal.py` startar Tk-applikationen.
+- UI- och presentationsmoduler under `src/` visar struktur, status, detaljer
+  och kartvyer.
+- Domänmoduler hanterar noder, resurser, befolkning, personliga provinser,
+  väder och relationer.
+- `src/time_engine.py` ansvarar för tidspositioner, deterministisk slump,
+  snapshots och beständig tidslinjedata.
+- `src/http_server.py` erbjuder en minimal HTML-presentation vid sidan av
+  Tk-klienten.
+- `src2/` är ett separat experiment i C++/SDL2 och ingår inte i den primära
+  Python-applikationens körväg.
+
+## Gränssnitt och dataflöden
+
+Världsdata läses in i domänobjekt och presenteras av klienterna. UI-kommandon
+ändrar planering eller driver tidsmotorn, som skapar snapshots och händelser.
+Personlig provinslogik kompletterar den administrativa nodhierarkin för
+ägande- och skatteflöden.
+
+## Kvalitetsattribut och constraints
+
+- Simuleringsutfall ska kunna reproduceras med deterministisk slump.
+- Tidigare snapshots ska vara oföränderliga ur användarflödets perspektiv.
+- Domänlogik ska kunna testas utan ett grafiskt fönster; UI-test ska kunna
+  hoppas över i headless-miljö.
+- Admin-läge och den administrativa hierarkin får inte påverkas oavsiktligt av
+  provinslägets presentationsväg.
+
+## Kopplade beslut och underlag
+
+- Beslut: inga formella beslutsposter ännu.
+- Underlag: `../evidence/source-inventory.md`.
+- Domänregler: `../domains/simulation.md`.
+
+## Historik
+
+- Ändringar kommer att sparas i `system-overview.Changelog.md`.

--- a/specs/decisions/README.md
+++ b/specs/decisions/README.md
@@ -1,0 +1,9 @@
+# Beslut
+
+Här sparas framtida beslutsposter med datum, status, valt alternativ, kontext,
+alternativ, konsekvenser och länkat underlag. Inga produktbeslut har antagits i
+den första konverteringen; öppna val finns i `../domains/simulation.md`.
+
+## Historik
+
+- Ändringar kommer att sparas i `README.Changelog.md`.

--- a/specs/domains/simulation.md
+++ b/specs/domains/simulation.md
@@ -1,0 +1,83 @@
+# Feodal simulering: verksamhetsbeskrivning och regler
+
+## Syfte
+
+Simulatorn ska beskriva en feodal värld där hierarkiska förläningar och deras
+lokala resurser kan granskas och förändras över tid. Tk-gränssnittet är den
+primära klienten; ett enklare HTTP-gränssnitt visar samma typ av data.
+
+## Begrepp
+
+- **Nod**: en förläning eller lokal resurs med identitet, egenskaper och
+  relationer.
+- **Feodal hierarki**: föräldra-/barnrelationer från överordnade områden till
+  underordnade förläningar och resurser.
+- **Administrativ väg**: hierarkin som redovisar befolkning och resurser.
+- **Personlig provinsväg**: ägarens provinsstruktur som styr skatteflödet.
+- **Snapshot**: en beständig kopia av världstillståndet vid en tidpunkt.
+- **Planeringsår**: valt år vars förändringar ännu inte har låsts genom
+  genomförande.
+
+## Bekräftade nulägesregler
+
+1. Världen består av hierarkiska noder med lokala resurser och befolkning.
+2. Noder kan ha grannar, och väder kan ge säsongsberoende mekaniska effekter.
+3. Det användarstyrda tidsflödet arbetar med hela år: genomförda år låses som
+   snapshots, medan planering får ske utan att äldre snapshots tas bort.
+4. Tidsmotorn kan samtidigt representera årstider och använder deterministisk
+   slump för reproducerbara väderutfall och snapshots.
+5. Administrativ väg och personlig provinsväg har skilda ansvar; provinsvägen
+   styr skatt enligt den befintliga Modell B-beskrivningen.
+6. Tk-klienten erbjuder struktur-, status- och detaljpaneler. HTTP-servern är
+   ett separat, enklare presentationsgränssnitt.
+
+## Framtida inriktning från referensmaterialet
+
+- Ekonomi med produktion, konsumtion och handel.
+- Befolkningsförändring, migration och sociala relationer.
+- Händelser på flera geografiska och hierarkiska nivåer.
+- Förgrening eller regenerering av framtiden efter ändringar bakåt i tiden.
+- Kart-, tidslinje- och förändringsvisualisering.
+
+Dessa punkter är kandidater, inte bekräftade implementationskrav.
+
+## Resonemang och antaganden
+
+- Nulägesregler prioriterar observerad dokumentation och implementerade
+  komponenter framför äldre visionstext.
+- Skillnaden mellan årsbaserat användarflöde och säsongsbaserad intern motor
+  behöver ett uttryckligt produktbeslut innan vidare tidsutveckling planeras.
+
+## Öppna frågor
+
+- [ ] Ska den styrande tidsenheten vara helt år, fyra årstider per år eller en
+  årsbaserad UI-modell ovanpå säsongssteg?
+- [ ] Vilka delar av den pensionerade ekonomivisionen är prioriterade krav?
+- [ ] Ska historiska ändringar regenerera en enda framtid eller skapa grenar?
+- [ ] Vilka händelser och relationer måste ingå i första kompletta simuleringen?
+
+## Kvalitetskontroll
+
+Senast kontrollerad: 2026-08-11
+
+### Motsägelser
+
+- `README.vision` anger fyra tidssteg per år, medan aktuell README beskriver
+  ett användarflöde med hela år. Frågan hålls öppen ovan.
+
+### Tvetydigheter
+
+- Begreppet "fullständig historik" saknar ännu beslut om lagringsnivå,
+  retention och eventuell förgrening.
+
+### Otydliga beskrivningar
+
+- Omfattningen av handel, politik, krig och allianser är inte specificerad.
+
+### Glapp i resonemang
+
+- Det saknas ännu mätbara acceptanskriterier för en "komplett" simulering.
+
+## Historik
+
+- Ändringar kommer att sparas i `simulation.Changelog.md`.

--- a/specs/evidence/source-inventory.md
+++ b/specs/evidence/source-inventory.md
@@ -1,0 +1,33 @@
+# Källinventering: underlag
+
+## Syfte
+
+Inventeringen anger vilket befintligt material som användes för den första
+strukturerade specifikationsuppsättningen.
+
+## Källor och observationer
+
+- `README.md` (läst 2026-08-11): beskriver körvägar, nuvarande UI, hela år,
+  snapshots, testning och personliga provinser.
+- `README.vision` (läst 2026-08-11): äldre vision om hierarki, ekonomi,
+  händelser, fyra tidssteg per år och historik. Dokumentet är nu retired och
+  endast referensmaterial.
+- `src/node.py`, `src/time_engine.py`, `src/events.py` och `src/weather.py`
+  (översiktligt lästa 2026-08-11): bekräftar centrala nod-, tids-, händelse-
+  och väderbegrepp.
+
+## Tolkning och begränsningar
+
+Inventeringen är en inledande källöversikt, inte en fullständig kodrevision.
+Visionens framtidsidéer har inte automatiskt gjorts till krav. Nya beslut ska
+spåras i `specs/decisions/` i stället för att skrivas tillbaka till visionen.
+
+## Stödjer
+
+- Krav: `../domains/simulation.md`.
+- Arkitektur: `../architecture/system-overview.md`.
+- Plan: `../plans/product-plan.md`.
+
+## Historik
+
+- Ändringar kommer att sparas i `source-inventory.Changelog.md`.

--- a/specs/plans/product-plan.Changelog.md
+++ b/specs/plans/product-plan.Changelog.md
@@ -1,0 +1,3 @@
+# Feodal simulering: implementationsplan – historik
+
+- 2026-08-11: Skapade första prioriterade planutkastet från strukturerade specifikationer.

--- a/specs/plans/product-plan.md
+++ b/specs/plans/product-plan.md
@@ -1,0 +1,49 @@
+# Feodal simulering: implementationsplan
+
+## Mål
+
+Förädla de strukturerade specifikationerna till beslutade, testbara krav innan
+nya produktionsändringar planeras.
+
+## Statusöversikt
+
+- Total status: `BLOCKED`
+- Senast uppdaterad: 2026-08-11
+- Blocker: öppna produktfrågor i `../domains/simulation.md`.
+
+## Prioritetsgrupper
+
+### P0 - Beslutsunderlag
+
+1. [OPEN] TIME-001 Besluta styrande tidsmodell
+   - Beskrivning: välj år, årstid eller års-UI ovanpå säsongssteg och definiera
+     snapshotfrekvens.
+   - Blocker: produktbeslut saknas.
+   - Kopplad specifikation: `../domains/simulation.md`.
+2. [OPEN] HISTORY-001 Besluta historik- och regenereringsmodell
+   - Beskrivning: definiera inkonsistens, regenerering, retention och grenar.
+   - Blocker: produktbeslut saknas.
+   - Kopplad specifikation: `../domains/simulation.md`.
+
+### P1 - Avgränsa domäner
+
+1. [BLOCKED] ECON-001 Specificera första ekonomiflödet
+   - Beskrivning: ange resurser, produktion, konsumtion och acceptanskriterier.
+   - Blocker: prioritering och tidsmodell är öppna.
+   - Kopplad specifikation: `../domains/simulation.md`.
+2. [BLOCKED] EVENT-001 Specificera första händelseflödet
+   - Beskrivning: ange nivåer, urval, effekter och reproducerbarhet.
+   - Blocker: omfattning och tidsmodell är öppna.
+   - Kopplad specifikation: `../domains/simulation.md`.
+
+### P2 - Implementation
+
+1. [DEFERRED] IMPL-001 Skapa kodnära genomförandeplan
+   - Beskrivning: bryt ned endast beslutade krav i små ändringar och fokuserade
+     tester.
+   - Blocker: P0 och relevanta P1-punkter måste vara lösta.
+   - Kopplad specifikation: `../domains/simulation.md`.
+
+## Historik
+
+- Ändringshistorik finns i `product-plan.Changelog.md`.

--- a/specs/prototyping/README.md
+++ b/specs/prototyping/README.md
@@ -1,0 +1,17 @@
+# Prototyping
+
+Avgränsade beslutstödjande POC:er får endast skapas här i bekräftat spec-läge.
+Varje POC ska ha verifierande testfall och beskriva hur resultatet återförs till
+de levande specifikationerna.
+
+## POC:er
+
+Statusvärden: `OPEN`, `FINISHED`.
+
+| POC | Status | Fråga | Senaste resultat |
+| --- | --- | --- | --- |
+| Inga | - | - | - |
+
+## Historik
+
+- Ändringar kommer att sparas i `README.Changelog.md`.

--- a/specs/schemas/README.md
+++ b/specs/schemas/README.md
@@ -1,0 +1,8 @@
+# Scheman
+
+Här sparas framtida databärande specifikationskontrakt. Den första
+struktureringen skapar eller ändrar inga JSON-, JRDL- eller andra scheman.
+
+## Historik
+
+- Ändringar kommer att sparas i `README.Changelog.md`.

--- a/specs/status/SPECSTATUS.Changelog.md
+++ b/specs/status/SPECSTATUS.Changelog.md
@@ -1,0 +1,3 @@
+# Specifikationsstatus: historik
+
+- 2026-08-11: Initierade strukturerad specmapp i SPEC-läge från uttrycklig begäran.

--- a/specs/status/SPECSTATUS.md
+++ b/specs/status/SPECSTATUS.md
@@ -1,0 +1,34 @@
+# Specifikationsstatus
+
+- Sticky specmapp: `specs/`
+- Repostatus: `SPEC`
+- Uppstartsnivå: `STRUCTURED`
+- Senast uppdaterad: 2026-08-11
+
+## Levande dokument
+
+- `specs/domains/simulation.md`: domänregler, utkast med öppna frågor.
+- `specs/architecture/system-overview.md`: arkitekturöversikt, första utgåva.
+- `specs/evidence/source-inventory.md`: källunderlag, första utgåva.
+- `specs/plans/product-plan.md`: implementationsplan, blockerad av öppna frågor.
+
+## Öppna frågor
+
+- Styrande tidsenhet och snapshotfrekvens.
+- Historisk regenerering kontra förgrenade tidslinjer.
+- Prioritering och avgränsning av ekonomi, händelser och relationer.
+
+## MCP-stöd
+
+- Tillgängligt: nej; inga projektspecifika MCP-resurser identifierades.
+- Källa för prioritering/åtgärder/status: repots dokument och kodöversikt.
+
+## Väntar på bekräftelse
+
+- Föreslaget byte: inget.
+- Fråga ställd: nej; användaren begärde uttryckligen att motsvarande
+  specifikationer skulle skapas.
+
+## Historik
+
+- Ändringshistorik finns i `SPECSTATUS.Changelog.md`.

--- a/specs/tmp/README.md
+++ b/specs/tmp/README.md
@@ -1,0 +1,8 @@
+# Temporära exporter
+
+Den här mappen är endast för genererade, temporära och icke-styrande
+granskningsdokument. Levande källor finns i övriga mappar under `specs/`.
+
+## Historik
+
+- Ändringar kommer att sparas i `README.Changelog.md`.


### PR DESCRIPTION
### Motivation

- Install a reusable specifications workflow into the repo and separate living specifications from the older vision document to make product/domain decisions traceable and reviewable. 
- Keep changes limited to documentation and skill installation and avoid touching core runtime pieces like server, JSON schemas, `world_manager`, or admin-mode. 

### Description

- Downloaded and vendored the `specifications-mode` skill under `.codex/skills/specifications-mode/` (added `SKILL.md`, templates and agent metadata) and verified parity with the installed skill. 
- Registered the skill and the sticky spec location in `AGENTS.md` and marked `README.vision` as retired reference material. 
- Created a structured `specs/` tree (`domains/`, `architecture/`, `plans/`, `decisions/`, `evidence/`, `schemas/`, `prototyping/`, `status/`, `tmp/`) with initial documents including `specs/README.md`, `specs/domains/simulation.md`, `specs/architecture/system-overview.md`, and `specs/status/SPECSTATUS.md`. 
- Added changelog stubs and ensured each primary spec document contains the required history footer and a `*.Changelog.md` where appropriate, keeping diffs minimal and only adding helper docs. 

### Testing

- Ran `python -m pip install -r requirements.txt && pytest` which completed with **454 passed, 115 skipped** and overall coverage reported at **89.05%**. 
- Verified repository and staged diffs with `git diff --cached --check` and ensured the installed skill and repo copy are identical via `diff -ru ${CODEX_HOME:-$HOME/.codex}/skills/specifications-mode .codex/skills/specifications-mode`. 
- Checked that all new primary spec `.md` files include the required `## Historik` footer via a small Python check script, and validated staged commit metadata. 

Commit: `5074c0e` — Diffstat: 19 files changed, 935 insertions, 0 deletions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b51cbda44832eb31dd0e323b52e0f)