### PR TITLE
Refresh specifications from code analysis

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -10,6 +10,8 @@ men skiljer bekräftade nulägeskrav från framtida idéer.
 - `architecture/system-overview.md`: systemgränser och huvudkomponenter.
 - `plans/product-plan.md`: prioriterade specifikations- och införandeåtgärder.
 - `status/SPECSTATUS.md`: aktuell repostatus, öppna frågor och levande dokument.
+- `status/outstanding-questions.md`: prioriterade kvarstående
+  specifikationsfrågor från kod- och dokumentanalys.
 - `decisions/`: framtida spårbara produkt- och arkitekturbeslut.
 - `evidence/source-inventory.md`: underlag och härledning från tidigare material.
 - `schemas/`: framtida databärande kontrakt; inga befintliga scheman ändras här.

--- a/specs/architecture/system-overview.Changelog.md
+++ b/specs/architecture/system-overview.Changelog.md
@@ -1,0 +1,3 @@
+# Systemöversikt: arkitektur – historik
+
+- 2026-08-11: Korrigerade aktiv tidsmotor och lade till provins-, rollup- och relationsgränser från kodanalysen.

--- a/specs/architecture/system-overview.md
+++ b/specs/architecture/system-overview.md
@@ -12,8 +12,15 @@ server, datakontrakt, `world_manager` eller admin-läge.
   och kartvyer.
 - Domänmoduler hanterar noder, resurser, befolkning, personliga provinser,
   väder och relationer.
-- `src/time_engine.py` ansvarar för tidspositioner, deterministisk slump,
-  snapshots och beständig tidslinjedata.
+- `src/time/time_engine.py` är Tk-klientens aktiva årsbaserade tidsmotor och
+  `src/time/weather_lock.py` låser deterministiskt väder per år. Den separata
+  `src/time_engine.py` implementerar en äldre säsongsbaserad och beständig
+  tidslinje men importeras inte av Tk-körvägen.
+- `src/rollup_policy.py` avgränsar vilka lokala värden som får bidra till
+  rekursiva rapporter; `WorldManager` utför traverseringen.
+- `src/world_relations.py` är en domänadapter för validering samt atomära läs-
+  och skrivoperationer för titel–säte och jarldöme–ägare. Detaljvyn använder
+  en separat presentationsadapter och visar relationerna skrivskyddat.
 - `src/http_server.py` erbjuder en minimal HTML-presentation vid sidan av
   Tk-klienten.
 - `src2/` är ett separat experiment i C++/SDL2 och ingår inte i den primära
@@ -24,7 +31,9 @@ server, datakontrakt, `world_manager` eller admin-läge.
 Världsdata läses in i domänobjekt och presenteras av klienterna. UI-kommandon
 ändrar planering eller driver tidsmotorn, som skapar snapshots och händelser.
 Personlig provinslogik kompletterar den administrativa nodhierarkin för
-ägande- och skatteflöden.
+ägande- och skatteflöden. Provinsvyn hämtar sitt träd via
+`get_province_subtree(owner_id)` och renderar svaret rekursivt under ett
+ägarankare; adminvyn byggs och återställs separat.
 
 ## Kvalitetsattribut och constraints
 
@@ -34,6 +43,10 @@ Personlig provinslogik kompletterar den administrativa nodhierarkin för
   hoppas över i headless-miljö.
 - Admin-läge och den administrativa hierarkin får inte påverkas oavsiktligt av
   provinslägets presentationsväg.
+- Rapportvärden ska räknas från lokala bidrag så att redan aggregerade värden
+  inte dubbelräknas vid rekursiv traversering.
+- Relationer ska valideras utan mutation; skrivoperationer får mutera först
+  när hela den begärda relationen är giltig.
 
 ## Kopplade beslut och underlag
 
@@ -43,4 +56,4 @@ Personlig provinslogik kompletterar den administrativa nodhierarkin för
 
 ## Historik
 
-- Ändringar kommer att sparas i `system-overview.Changelog.md`.
+- Ändringshistorik finns i `system-overview.Changelog.md`.

--- a/specs/domains/simulation.Changelog.md
+++ b/specs/domains/simulation.Changelog.md
@@ -1,0 +1,3 @@
+# Feodal simulering: verksamhetsbeskrivning och regler – historik
+
+- 2026-08-11: Synkroniserade tids-, provins-, sammanräknings- och relationsregler med implementerad kod.

--- a/specs/domains/simulation.md
+++ b/specs/domains/simulation.md
@@ -17,6 +17,10 @@ primära klienten; ett enklare HTTP-gränssnitt visar samma typ av data.
 - **Snapshot**: en beständig kopia av världstillståndet vid en tidpunkt.
 - **Planeringsår**: valt år vars förändringar ännu inte har låsts genom
   genomförande.
+- **Titelrelation**: uttrycklig koppling från en titel på nivå 0–2 till ett
+  jarldöme på nivå 3 som fungerar som titelns säte.
+- **Jarldömesägare**: uttrycklig koppling från ett jarldöme på nivå 3 till en
+  person i världens globala personregister.
 
 ## Bekräftade nulägesregler
 
@@ -24,12 +28,25 @@ primära klienten; ett enklare HTTP-gränssnitt visar samma typ av data.
 2. Noder kan ha grannar, och väder kan ge säsongsberoende mekaniska effekter.
 3. Det användarstyrda tidsflödet arbetar med hela år: genomförda år låses som
    snapshots, medan planering får ske utan att äldre snapshots tas bort.
-4. Tidsmotorn kan samtidigt representera årstider och använder deterministisk
-   slump för reproducerbara väderutfall och snapshots.
+4. Den aktiva Tk-körvägen använder `src/time/time_engine.py`: väder låses per
+   helt år och genereras reproducerbart från året, med ett utfall per årstid.
+   Den äldre säsongsbaserade motorn i `src/time_engine.py` är inte inkopplad i
+   Tk-klienten.
 5. Administrativ väg och personlig provinsväg har skilda ansvar; provinsvägen
    styr skatt enligt den befintliga Modell B-beskrivningen.
 6. Tk-klienten erbjuder struktur-, status- och detaljpaneler. HTTP-servern är
    ett separat, enklare presentationsgränssnitt.
+7. Provinsläget visar ägarens ankare och bygger därefter hela trädet från
+   `get_province_subtree(owner_id)` med rekursiv insert. En explicit ägare på
+   en undernod bryter nedärvningen från en överordnad ägare; adminträdet har en
+   separat renderingsväg och återställs när läget lämnas.
+8. Sammanräkningar använder lokala bidrag för att undvika dubbelräkning:
+   fysisk lagring kommer endast från `Lager`-noder, medan befolkning och arbete
+   räknas enligt respektive lokala policy.
+9. Titel–säte och jarldöme–ägare är separata, explicita relationer. Ett säte
+   måste vara ett jarldöme i titelns administrativa delträd och får inte delas
+   av flera titlar. En jarldömesägare måste finnas i personregistret; ingen av
+   relationerna härleds automatiskt från den andra eller från provinsägandet.
 
 ## Framtida inriktning från referensmaterialet
 
@@ -46,7 +63,8 @@ Dessa punkter är kandidater, inte bekräftade implementationskrav.
 - Nulägesregler prioriterar observerad dokumentation och implementerade
   komponenter framför äldre visionstext.
 - Skillnaden mellan årsbaserat användarflöde och säsongsbaserad intern motor
-  behöver ett uttryckligt produktbeslut innan vidare tidsutveckling planeras.
+  består i praktiken av två motorimplementationer och behöver ett uttryckligt
+  produktbeslut innan vidare tidsutveckling planeras.
 
 ## Öppna frågor
 
@@ -55,6 +73,8 @@ Dessa punkter är kandidater, inte bekräftade implementationskrav.
 - [ ] Vilka delar av den pensionerade ekonomivisionen är prioriterade krav?
 - [ ] Ska historiska ändringar regenerera en enda framtid eller skapa grenar?
 - [ ] Vilka händelser och relationer måste ingå i första kompletta simuleringen?
+- [ ] Ska de explicita titel- och ägarrelationerna förbli endast läsbara i UI,
+  eller ska ett framtida icke-adminflöde få redigera dem?
 
 ## Kvalitetskontroll
 
@@ -69,6 +89,9 @@ Senast kontrollerad: 2026-08-11
 
 - Begreppet "fullständig historik" saknar ännu beslut om lagringsnivå,
   retention och eventuell förgrening.
+- "Ägare" kan avse både personlig provinstilldelning och den separata
+  relationen mellan person och jarldöme; specifikation och UI måste namnge
+  vilken relation som avses.
 
 ### Otydliga beskrivningar
 
@@ -80,4 +103,4 @@ Senast kontrollerad: 2026-08-11
 
 ## Historik
 
-- Ändringar kommer att sparas i `simulation.Changelog.md`.
+- Ändringshistorik finns i `simulation.Changelog.md`.

--- a/specs/evidence/source-inventory.Changelog.md
+++ b/specs/evidence/source-inventory.Changelog.md
@@ -1,0 +1,3 @@
+# Källinventering: underlag – historik
+
+- 2026-08-11: Utökade underlaget med aktiv tidskörväg, provinsrendering, rollup-policy och världsrelationer.

--- a/specs/evidence/source-inventory.md
+++ b/specs/evidence/source-inventory.md
@@ -12,13 +12,21 @@ strukturerade specifikationsuppsättningen.
 - `README.vision` (läst 2026-08-11): äldre vision om hierarki, ekonomi,
   händelser, fyra tidssteg per år och historik. Dokumentet är nu retired och
   endast referensmaterial.
-- `src/node.py`, `src/time_engine.py`, `src/events.py` och `src/weather.py`
-  (översiktligt lästa 2026-08-11): bekräftar centrala nod-, tids-, händelse-
-  och väderbegrepp.
+- `src/feodal_simulator.py`, `src/time/time_engine.py` och
+  `src/time/weather_lock.py` (lästa 2026-08-11): bekräftar att Tk-körvägen är
+  årsbaserad, bevarar låsta snapshots och låser reproducerbart årsväder.
+- `src/time_engine.py` (läst 2026-08-11): innehåller en separat säsongsbaserad
+  motor med beständig lagring, men saknar import från Tk-körvägen.
+- `src/personal_province.py`, `src/ui/views/structure_view.py` och relevanta
+  domän-/UI-tester (lästa 2026-08-11): bekräftar ägararv, avbrott vid explicit
+  underägare och att provinsrendering utgår från `get_province_subtree`.
+- `src/rollup_policy.py`, `src/world_relations.py` och deras tester (lästa
+  2026-08-11): bekräftar lokala bidragspolicyer samt explicita, validerade
+  titel–säte- och jarldöme–ägare-relationer.
 
 ## Tolkning och begränsningar
 
-Inventeringen är en inledande källöversikt, inte en fullständig kodrevision.
+Inventeringen är en riktad kodanalys, inte en fullständig rad-för-rad-revision.
 Visionens framtidsidéer har inte automatiskt gjorts till krav. Nya beslut ska
 spåras i `specs/decisions/` i stället för att skrivas tillbaka till visionen.
 
@@ -30,4 +38,4 @@ spåras i `specs/decisions/` i stället för att skrivas tillbaka till visionen.
 
 ## Historik
 
-- Ändringar kommer att sparas i `source-inventory.Changelog.md`.
+- Ändringshistorik finns i `source-inventory.Changelog.md`.

--- a/specs/plans/product-plan.Changelog.md
+++ b/specs/plans/product-plan.Changelog.md
@@ -1,3 +1,4 @@
 # Feodal simulering: implementationsplan – historik
 
+- 2026-08-11: Lade till beslutspunkt för relationsbegrepp och skrivskyddat UI efter kodanalys.
 - 2026-08-11: Skapade första prioriterade planutkastet från strukturerade specifikationer.

--- a/specs/plans/product-plan.md
+++ b/specs/plans/product-plan.md
@@ -24,6 +24,11 @@ nya produktionsändringar planeras.
    - Beskrivning: definiera inkonsistens, regenerering, retention och grenar.
    - Blocker: produktbeslut saknas.
    - Kopplad specifikation: `../domains/simulation.md`.
+3. [OPEN] REL-001 Besluta relationsbegrepp och UI-ansvar
+   - Beskrivning: skilj personlig provinsägare från jarldömesägare och avgör
+     om explicita titel-/ägarrelationer ska förbli skrivskyddade i UI.
+   - Blocker: produktbeslut saknas; admin-läge ingår inte i ändringsytan.
+   - Kopplad specifikation: `../status/outstanding-questions.md`.
 
 ### P1 - Avgränsa domäner
 

--- a/specs/status/SPECSTATUS.Changelog.md
+++ b/specs/status/SPECSTATUS.Changelog.md
@@ -1,3 +1,4 @@
 # Specifikationsstatus: historik
 
+- 2026-08-11: Synkroniserade levande specifikationer med aktiv kod och skapade en prioriterad frågelista.
 - 2026-08-11: Initierade strukturerad specmapp i SPEC-läge från uttrycklig begäran.

--- a/specs/status/SPECSTATUS.md
+++ b/specs/status/SPECSTATUS.md
@@ -11,12 +11,16 @@
 - `specs/architecture/system-overview.md`: arkitekturöversikt, första utgåva.
 - `specs/evidence/source-inventory.md`: källunderlag, första utgåva.
 - `specs/plans/product-plan.md`: implementationsplan, blockerad av öppna frågor.
+- `specs/status/outstanding-questions.md`: prioriterade kvarstående
+  specifikationsfrågor efter kodanalys.
 
 ## Öppna frågor
 
 - Styrande tidsenhet och snapshotfrekvens.
 - Historisk regenerering kontra förgrenade tidslinjer.
 - Prioritering och avgränsning av ekonomi, händelser och relationer.
+- UI-ansvar och terminologi för explicita titel-/ägarrelationer jämfört med
+  personlig provinstilldelning.
 
 ## MCP-stöd
 

--- a/specs/status/outstanding-questions.md
+++ b/specs/status/outstanding-questions.md
@@ -1,0 +1,21 @@
+# Kvarstående specifikationsfrågor
+
+## P0 – blockerar tidsplanering
+
+1. Ska årsmodellen i `src/time/time_engine.py` vara styrande, eller ska den
+   säsongsbaserade modellen i `src/time_engine.py` ersätta den?
+2. Ska historiska ändringar behålla låsta snapshots, regenerera en enda
+   framtid eller skapa förgrenade tidslinjer?
+
+## P1 – blockerar domänavgränsning
+
+1. Vilket minsta ekonomi-, händelse- och relationsflöde definierar den första
+   kompletta simuleringen, med mätbara acceptanskriterier?
+2. Ska titel–säte och jarldöme–ägare förbli skrivskyddade i användargränssnittet
+   eller få ett framtida redigeringsflöde utanför admin-läget?
+3. Hur ska termen "ägare" namnges i krav och UI så att personlig
+   provinstilldelning inte sammanblandas med jarldömets personrelation?
+
+## Historik
+
+- Ändringar kommer att sparas i `outstanding-questions.Changelog.md`.


### PR DESCRIPTION
### Motivation

- Align the living specifications with the repository's actual implementation of the time, province, rollup and world-relations code paths so the docs reflect current behavior. 
- Surface remaining product decisions and terminology ambiguities (time model vs seasonal engine, and the multiple senses of “owner”) that block safe implementation work. 
- Keep admin-mode behavior and production code unchanged while adding spec clarifications and a prioritized question list.

### Description

- Synchronized domain and architecture docs to reflect that the Tk client uses the years-based engine at `src/time/time_engine.py` and that `src/time_engine.py` is a separate, not-imported seasonal motor, and documented `src/time/weather_lock.py` behavior.  
- Clarified province-mode rendering rules to state that province views are built from `get_province_subtree(owner_id)` with recursive insert and that admin-mode rendering is separate.  
- Documented rollup and world-relation boundaries: noted `src/rollup_policy.py` local-contribution rules and `src/world_relations.py` explicit, validated title-seat and jarldom-owner adapters, and that relation mutations must be atomic/validated.  
- Added a prioritized outstanding-specification question list (`specs/status/outstanding-questions.md`) and a new `REL-001` decision item in the product plan to decide relations terminology and UI responsibility.  
- Added changelog files and small editorial fixes across `specs/README.md`, `specs/domains/simulation.md`, `specs/architecture/system-overview.md`, `specs/evidence/source-inventory.md`, `specs/plans/product-plan.md`, and `specs/status/SPECSTATUS.md` to record the sync with code.

### Testing

- Installed test dependencies with `python -m pip install -r requirements.txt` (setup completed). 
- Ran the full test-suite with `pytest`, which completed successfully with **454 passed, 115 skipped**, and **1 warning**. 
- Reported coverage: total coverage **89.05%**, which satisfies repository requirements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b5707267c832e928674abe769aac4)