### PR TITLE
specs: describe identified simulation domains

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -6,7 +6,8 @@ men skiljer bekräftade nulägeskrav från framtida idéer.
 
 ## Dokument
 
-- `domains/simulation.md`: verksamhetsbeskrivning, begrepp och regler.
+- `domains/README.md`: karta över identifierade verksamhetsdomäner.
+- `domains/simulation.md`: gemensam verksamhetsbeskrivning, begrepp och regler.
 - `architecture/system-overview.md`: systemgränser och huvudkomponenter.
 - `plans/product-plan.md`: prioriterade specifikations- och införandeåtgärder.
 - `status/SPECSTATUS.md`: aktuell repostatus, öppna frågor och levande dokument.

--- a/specs/domains/README.md
+++ b/specs/domains/README.md
@@ -1,0 +1,46 @@
+# Identifierade domäner
+
+## Syfte
+
+Den här katalogen delar upp simulatorns verksamhetsområde i sammanhängande
+domäner. Indelningen beskriver ansvar och språk; den föreskriver inte att varje
+domän måste bli en egen teknisk komponent.
+
+## Domänkarta
+
+| Domän | Ansvar | Nuvarande mognad |
+| --- | --- | --- |
+| [Världsstruktur](world-structure.md) | Feodal hierarki, noder, lokala resurser, grannar och gränser | Implementerad kärna |
+| [Ägande och auktoritet](ownership-and-authority.md) | Personliga provinser, skattevägar, titel–säte och jarldöme–person | Delvis implementerad |
+| [Befolkning och ekonomi](population-and-economy.md) | Befolkningsgrupper, arbete, lager, licensintäkter och aggregering | Delvis implementerad |
+| [Tid, väder och händelser](time-weather-and-events.md) | Planeringsår, snapshots, determinism, väder och domänhändelser | Två konkurrerande tidsmodeller |
+| [Personer och hushåll](people-and-households.md) | Personregister, adelsfamilj, levnadsstandard, bostad och tjänstestab | Delvis implementerad |
+
+`simulation.md` är den gemensamma översikten. Dokumenten ovan fördjupar
+identifierade domäner utan att göra framtidsidéer till bekräftade krav.
+
+## Samspel
+
+1. Världsstrukturen ger identitet och administrativa vägar åt övriga domäner.
+2. Ägande och auktoritet lägger alternativa personliga skattevägar samt
+   explicita maktrelationer ovanpå strukturen.
+3. Befolkning och ekonomi hämtar lokala bidrag från världens noder och
+   sammanställer dem längs valda vägar.
+4. Tid, väder och händelser anger när tillstånd får ändras, låsas och
+   reproduceras.
+5. Personer och hushåll tillhandahåller personer som kan bära relationer och
+   hushållskrav som förbrukar ekonomiska resurser.
+
+## Avgränsning
+
+- Tk- och HTTP-gränssnitten är presentationskanaler, inte egna
+  verksamhetsdomäner.
+- JSON-lagring, adapters och UI-paneler är tekniska stödansvar.
+- Kartverktyget och `src2/` är experiment och ingår inte i den bekräftade
+  simuleringskärnan.
+- Handel, krig, allianser och fullständig demografi är ännu kandidater till
+  framtida domäner eller utökningar, inte identifierade nulägeskrav.
+
+## Historik
+
+- Ändringar kommer att sparas i `README.Changelog.md`.

--- a/specs/domains/ownership-and-authority.md
+++ b/specs/domains/ownership-and-authority.md
@@ -1,0 +1,58 @@
+# Domän: ägande och auktoritet
+
+## Verksamhetsansvar
+
+Domänen skiljer tre relationer som beskriver olika slags kontroll: personlig
+provinstilldelning, en titels säte och en persons relation till ett jarldöme.
+Relationerna får inte härledas automatiskt från varandra.
+
+## Centrala begrepp
+
+- **Personlig provinsägare**: nod på nivå 0–2 som fungerar som ankare för ett
+  jarldömes personliga provinsväg.
+- **Personlig provinsväg**: härledd lista av administrativa förfäder fram till
+  valt ägarankare.
+- **Titel**: nod på nivå 0–2 som kan ha ett explicit säte.
+- **Säte**: jarldöme på nivå 3 inom titelns administrativa delträd.
+- **Jarldömesägare**: person i det globala personregistret som explicit
+  relaterats till ett jarldöme.
+- **Administrativ intäkt** respektive **personlig intäkt**: skilda vyer av
+  skatteflödet.
+
+## Bekräftade regler
+
+1. Ett jarldöme kan tilldelas högst ett personligt ägarankare på nivå 0, 1
+   eller 2, eller sakna sådan tilldelning.
+2. Ankaret måste finnas på angiven nivå och får varken vara jarldömet självt
+   eller en av dess efterkommande.
+3. En explicit ägare på en undernod bryter nedärvningen från en överordnad
+   personlig ägare i provinsvyn.
+4. Skatteandelarna normaliseras till intervallet 0–1 och därefter så att
+   lokal andel och vidarebefordrad andel tillsammans utgör hela inkomsten.
+5. Ett titel–säte måste gå från nivå 0–2 till ett unikt jarldöme på nivå 3 i
+   titelns delträd. Samma jarldöme får inte vara säte för flera titlar.
+6. En jarldömesägare måste finnas i det globala personregistret.
+7. Relationsvalidering får inte mutera världsdata. En skrivoperation får
+   mutera först när hela relationen är giltig.
+8. Ändrad personlig provinsägare skapar en inspektionssnapshot och publicerar
+   en ägarändringshändelse när en händelsebuss finns.
+
+## Domängränser
+
+- Administrativ hierarki och nodnivåer kommer från världsstrukturen.
+- Personidentitet kommer från personer och hushåll.
+- Domänen definierar skattevägen men inte produktionen av den beskattningsbara
+  inkomsten.
+
+## Kvalitetskontroll
+
+- **Tvetydighet:** ordet "ägare" betecknar både provinsankare och
+  jarldöme–person; krav och UI behöver konsekvent kvalificerade namn.
+- **Otydlighet:** sink-nivåerna i Modell B finns i kod men deras fullständiga
+  verksamhetsbetydelse och bokföring är inte dokumenterade.
+- **Öppen produktfråga:** titel–säte och jarldömesägare är läsbara i ordinarie
+  UI, men framtida redigeringsansvar är inte beslutat.
+
+## Historik
+
+- Ändringar kommer att sparas i `ownership-and-authority.Changelog.md`.

--- a/specs/domains/people-and-households.md
+++ b/specs/domains/people-and-households.md
@@ -1,0 +1,52 @@
+# Domän: personer och hushåll
+
+## Verksamhetsansvar
+
+Domänen beskriver identifierbara personer och den nuvarande modellen för ett
+adligt hushålls sammansättning, levnadsstandard, bostad och tjänstebehov.
+Den omfattar ännu inte en generell livscykel- eller relationssimulering.
+
+## Centrala begrepp
+
+- **Personregister**: världens globala uppslag av personer efter identitet.
+- **Adelsfamilj**: länsherre, makar, barn och släktingar knutna till en nod.
+- **Platshållare**: namngiven hushållsmedlem utan fullständig personpost.
+- **Levnadsstandard**: ordinal nivå från Enkel till Furstlig.
+- **Bostadskrav**: lägsta byggnadstyp som stödjer en levnadsstandard.
+- **Tjänstestab**: beräknat antal roller för ett hushåll vid en viss
+  levnadsnivå.
+
+## Bekräftade regler
+
+1. En hushållsmedlem räknas om posten är en giltig personreferens, en namngiven
+   platshållare eller ett bakåtkompatibelt enkelt värde.
+2. Hushållets storlek är summan av länsherre, makar, barn och släktingar.
+3. Levnadsstandarderna har en fast ordning och mappar till levnadsnivå samt
+   bostadstyp.
+4. Högsta tillåtna standard begränsas av den högst rankade tillgängliga
+   bostadsbyggnaden.
+5. Tjänstebehov och kostnad beräknas från levnadsnivå och antal adliga
+   hushållsmedlemmar enligt rollspecifika tabeller.
+6. En explicit jarldömesägare måste referera en person i det globala
+   registret; en lokal karaktärsresurs är inte automatiskt samma relation.
+
+## Domängränser
+
+- Ägande och auktoritet äger relationen mellan person och jarldöme.
+- Befolkning och ekonomi äger aggregerade befolkningsgrupper och ekonomiska
+  resurser; hushållet beskriver specifika personer och deras krav.
+- Byggnader ligger lokalt i världsstrukturen men tolkas här som stöd för
+  levnadsstandard.
+
+## Kvalitetskontroll
+
+- **Tvetydighet:** globala personer, lokala `characters`-poster,
+  `ruler_id` och hushållsplatshållare bildar ännu ingen enhetlig personmodell.
+- **Glapp:** födelse, död, ålder, släktskap, succession och relationers
+  förändring över tid saknar bekräftade regler.
+- **Otydlighet:** tjänstekostnadernas enhet och koppling till lager eller
+  årsbudget är inte specificerad.
+
+## Historik
+
+- Ändringar kommer att sparas i `people-and-households.Changelog.md`.

--- a/specs/domains/population-and-economy.md
+++ b/specs/domains/population-and-economy.md
@@ -1,0 +1,57 @@
+# Domän: befolkning och ekonomi
+
+## Verksamhetsansvar
+
+Domänen beskriver lokala människor, arbete, lager och nuvarande enkla
+intäkter samt hur värden får summeras genom världens hierarki. Den är ännu
+inte en fullständig produktions-, konsumtions- eller handelsmodell.
+
+## Centrala begrepp
+
+- **Befolkningsgrupp**: fria bönder, ofria bönder, trälar eller borgare.
+- **Lokalt bidrag**: värde som har sitt ursprung på en nod och därför får
+  räknas exakt en gång i en rekursiv sammanställning.
+- **Dagsverken**: arbetsplikt för ofria bönder med en vald nivå.
+- **Tillgängligt arbete**: arbetsdagar från trälar, ofria bönder och anlitade
+  daglönare enligt respektive faktor.
+- **Arbetsbehov**: lokalt registrerat behov; fiskevatten använder antal båtar.
+- **Lager**: fysisk resursnod för basvaror, lyxvaror, silver och råmaterial.
+- **Licensintäkt**: nuvarande schablonintäkt från hantverkare.
+
+## Bekräftade regler
+
+1. Lokal befolkning är summan av uttryckliga befolkningsgrupper när sådana
+   fält finns. Vildmark och jaktmark har ingen befolkning.
+2. Ett redan aggregerat värde på en föräldranod får inte återräknas som lokalt
+   bidrag. Lövnoder kan använda ett äldre `population`-fält som reserv.
+3. Negativa eller ogiltiga lokala tal bidrar med noll vid sammanställning.
+4. Endast `Lager`-noder bidrar med fysisk lagring till rekursiva rapporter.
+5. Tillgängligt arbete beräknas från trälar, ofria bönder och anlitade
+   daglönare. Dagsverkesnivån styr de ofria böndernas faktor.
+6. Arbetsbehov på administrativa nivåer 0–3 bidrar inte lokalt. Hav och flod
+   använder fiskebåtar multiplicerat med träls arbetsdagsfaktor.
+7. Hantverkares licensintäkt bygger på en fast avgift per yrkestyp och lagrat
+   antal.
+8. Personlig skattefördelning konsumerar en beräknad jarldömesintäkt men hålls
+   begreppsligt skild från administrativ resursredovisning.
+
+## Domängränser
+
+- Världsstrukturen anger var lokala bidrag finns och hur de traverseras.
+- Ägande och auktoritet avgör vem som behåller eller tar emot vidarebefordrad
+  skatt.
+- Väder kan senare påverka produktion, men någon sådan komplett koppling är
+  inte ett bekräftat nulägesflöde.
+
+## Kvalitetskontroll
+
+- **Glapp:** produktion, konsumtion, priser, handel och faktiskt skatteunderlag
+  saknar sammanhängande regler och acceptanskriterier.
+- **Tvetydighet:** `population` kan vara lokalt arvfält eller aggregerat värde;
+  den lokala bidragspolicyn mildrar men eliminerar inte datatvetydigheten.
+- **Otydlighet:** relationen mellan arbetsbehov, tillgängligt arbete,
+  umbärande och resursutfall är inte specificerad som ett årsflöde.
+
+## Historik
+
+- Ändringar kommer att sparas i `population-and-economy.Changelog.md`.

--- a/specs/domains/simulation.Changelog.md
+++ b/specs/domains/simulation.Changelog.md
@@ -1,3 +1,4 @@
 # Feodal simulering: verksamhetsbeskrivning och regler – historik
 
+- 2026-08-12: Länkade översikten till fem identifierade och fördjupade domäner.
 - 2026-08-11: Synkroniserade tids-, provins-, sammanräknings- och relationsregler med implementerad kod.

--- a/specs/domains/simulation.md
+++ b/specs/domains/simulation.md
@@ -6,6 +6,18 @@ Simulatorn ska beskriva en feodal värld där hierarkiska förläningar och dera
 lokala resurser kan granskas och förändras över tid. Tk-gränssnittet är den
 primära klienten; ett enklare HTTP-gränssnitt visar samma typ av data.
 
+## Identifierade domäner
+
+Simulatorns verksamhetsområde är uppdelat i fem samverkande domäner:
+
+- [Världsstruktur](world-structure.md)
+- [Ägande och auktoritet](ownership-and-authority.md)
+- [Befolkning och ekonomi](population-and-economy.md)
+- [Tid, väder och händelser](time-weather-and-events.md)
+- [Personer och hushåll](people-and-households.md)
+
+Domänkartan och avgränsningen finns i [domänkatalogens README](README.md).
+
 ## Begrepp
 
 - **Nod**: en förläning eller lokal resurs med identitet, egenskaper och
@@ -78,7 +90,7 @@ Dessa punkter är kandidater, inte bekräftade implementationskrav.
 
 ## Kvalitetskontroll
 
-Senast kontrollerad: 2026-08-11
+Senast kontrollerad: 2026-08-12
 
 ### Motsägelser
 

--- a/specs/domains/time-weather-and-events.md
+++ b/specs/domains/time-weather-and-events.md
@@ -1,0 +1,58 @@
+# Domän: tid, väder och händelser
+
+## Verksamhetsansvar
+
+Domänen ordnar förändringar i simuleringsvärlden, låser historiskt tillstånd
+och ger reproducerbara omvärldsutfall. Nuläget har en aktiv årsmodell och en
+äldre, fristående säsongsmodell; vilken som ska vara långsiktigt styrande är
+inte beslutat.
+
+## Centrala begrepp
+
+- **Planeringsår**: valt helt år vars tillstånd kan ändras före genomförande.
+- **Låst år**: genomfört år med en snapshot.
+- **Ej beräknat år**: framtida platshållare utan låst utfall.
+- **Snapshot**: djup kopia av världstillståndet vid en tidsposition.
+- **Årsväder**: reproducerbart utfall med ett värde per årstid inom ett år.
+- **Domänhändelse**: meddelande om ett inträffat domänfaktum, exempelvis
+  ändrad personlig provinsägare.
+
+## Bekräftade regler för aktiv Tk-körväg
+
+1. Användaren navigerar i hela år och kan inte gå före år 1.
+2. Planeringsändringar lagras per valt år och får inte radera äldre låsta år.
+3. Genomförande kopierar planeringstillståndet, kör en valfri
+   beräkningsfunktion, låser resultatet och öppnar nästa planeringsår.
+4. Utlämnade snapshots är kopior; anroparen ska inte kunna mutera motorns
+   interna historik genom dem.
+5. Väder låses deterministiskt från året och ger vår-, sommar-, höst- och
+   vinterutfall även om användarens styrande tidssteg är ett helt år.
+
+## Separat äldre modell
+
+`src/time_engine.py` går i årstider, sparar komprimerade snapshots med
+checksumma och tidslinje-id samt kan markera och trunkera en smutsig framtid.
+Den importeras inte av den aktiva Tk-klienten. Dess beteende är därför underlag
+för ett framtida beslut, inte bindande nulägeskrav.
+
+## Domängränser
+
+- Domänen styr ordning, reproducerbarhet och historik, men varje annan domän
+  äger sina egna beräkningsregler.
+- Händelsebussen distribuerar fakta och ska inte vara den auktoritativa
+  lagringen av världstillstånd.
+- Väderutfall finns, men effekter på ekonomi och befolkning kräver separata
+  domänregler.
+
+## Kvalitetskontroll
+
+- **Motsägelse:** referensvisionens fyra styrande tidssteg per år skiljer sig
+  från den aktiva årsmodellen.
+- **Glapp:** retention, regenerering efter historisk ändring och eventuella
+  förgrenade tidslinjer saknar produktbeslut.
+- **Otydlighet:** vilka domänberäkningar som måste ske vid genomförande av ett
+  år är ännu inte definierat.
+
+## Historik
+
+- Ändringar kommer att sparas i `time-weather-and-events.Changelog.md`.

--- a/specs/domains/world-structure.md
+++ b/specs/domains/world-structure.md
@@ -1,0 +1,52 @@
+# Domän: världsstruktur
+
+## Verksamhetsansvar
+
+Domänen beskriver den feodala världens rumsliga och administrativa stomme.
+Den avgör vilka objekt som finns, hur de är underordnade varandra och vilka
+lokala egenskaper som kan sammanställas av andra domäner.
+
+## Centrala begrepp
+
+- **Värld**: en samling noder, personer och explicita relationstabeller.
+- **Nod**: identifierbart objekt med en valfri förälder, barn och lokala data.
+- **Djup**: nodens nivå i föräldrahierarkin; nivå 0–2 representerar titlar och
+  nivå 3 ett jarldöme i de explicita relationsreglerna.
+- **Resursnod**: undernod som bär ett lokalt bidrag, exempelvis lager,
+  befolkning, mark, byggnad, djur eller väder.
+- **Granne**: högst en koppling i vardera av nodens sex grannplatser.
+- **Gränstyp**: egenskap på en grannkoppling, exempelvis väg, berg eller
+  vattendrag.
+
+## Bekräftade regler
+
+1. Nodidentiteter ska kunna normaliseras från heltal eller numeriska strängar.
+2. Föräldra-/barnrelationen definierar den administrativa hierarkin och får
+   inte antas vara samma sak som en personlig provinsväg.
+3. Traversering måste skydda mot cykler och saknade noder; ogiltig härkomst
+   får inte användas för att härleda giltiga titel- eller ägarrelationer.
+4. En nod har högst sex normaliserade grannplatser. En grannrelation och dess
+   gränstyp ska hållas konsekvent mellan båda noderna när de redigeras.
+5. Radering av en nod omfattar dess administrativa efterkommande.
+6. Resurstypen avgör vilka lokala fält som har verksamhetsbetydelse. Exempelvis
+   kommer fysisk lagring endast från noder av typen `Lager`.
+
+## Domängränser
+
+- Domänen äger struktur och lokal placering, men inte reglerna för
+  skattefördelning eller personrelationer.
+- Summeringsregler definieras i befolknings- och ekonomidomänen.
+- Titel–säte använder strukturen för validering men ägs av domänen ägande och
+  auktoritet.
+
+## Kvalitetskontroll
+
+- **Tvetydighet:** nivåernas fullständiga verksamhetsnamn och tillåtna antal
+  nivåer är inte samlat specificerade.
+- **Glapp:** regler för flytt av en hel delhierarki och följdeffekter på
+  grannar, säten och personliga vägar saknas.
+- **Motsägelse:** ingen direkt motsägelse identifierad i nulägesunderlaget.
+
+## Historik
+
+- Ändringar kommer att sparas i `world-structure.Changelog.md`.

--- a/specs/evidence/source-inventory.Changelog.md
+++ b/specs/evidence/source-inventory.Changelog.md
@@ -1,3 +1,4 @@
 # Källinventering: underlag – historik
 
+- 2026-08-12: Utökade kodunderlaget för de identifierade domänbeskrivningarna.
 - 2026-08-11: Utökade underlaget med aktiv tidskörväg, provinsrendering, rollup-policy och världsrelationer.

--- a/specs/evidence/source-inventory.md
+++ b/specs/evidence/source-inventory.md
@@ -23,6 +23,11 @@ strukturerade specifikationsuppsättningen.
 - `src/rollup_policy.py`, `src/world_relations.py` och deras tester (lästa
   2026-08-11): bekräftar lokala bidragspolicyer samt explicita, validerade
   titel–säte- och jarldöme–ägare-relationer.
+- `src/node.py`, `src/world_manager.py`, `src/constants.py`,
+  `src/population_utils.py`, `src/noble_staff.py`, `src/weather.py` och
+  `src/events.py` (lästa 2026-08-12): underlag för domänindelningen och
+  nulägesregler om struktur, grannar, befolkning, arbete, lager, hushåll,
+  väder och händelser.
 
 ## Tolkning och begränsningar
 

--- a/specs/status/SPECSTATUS.Changelog.md
+++ b/specs/status/SPECSTATUS.Changelog.md
@@ -1,4 +1,5 @@
 # Specifikationsstatus: historik
 
+- 2026-08-12: Registrerade domänkartan och fem fördjupade domänbeskrivningar som levande dokument.
 - 2026-08-11: Synkroniserade levande specifikationer med aktiv kod och skapade en prioriterad frågelista.
 - 2026-08-11: Initierade strukturerad specmapp i SPEC-läge från uttrycklig begäran.

--- a/specs/status/SPECSTATUS.md
+++ b/specs/status/SPECSTATUS.md
@@ -3,11 +3,14 @@
 - Sticky specmapp: `specs/`
 - Repostatus: `SPEC`
 - Uppstartsnivå: `STRUCTURED`
-- Senast uppdaterad: 2026-08-11
+- Senast uppdaterad: 2026-08-12
 
 ## Levande dokument
 
-- `specs/domains/simulation.md`: domänregler, utkast med öppna frågor.
+- `specs/domains/README.md`: domänkarta med fem identifierade domäner.
+- `specs/domains/simulation.md`: gemensamma domänregler och öppna frågor.
+- `specs/domains/*.md`: fördjupningar av världsstruktur, ägande och auktoritet,
+  befolkning och ekonomi, tid/väder/händelser samt personer och hushåll.
 - `specs/architecture/system-overview.md`: arkitekturöversikt, första utgåva.
 - `specs/evidence/source-inventory.md`: källunderlag, första utgåva.
 - `specs/plans/product-plan.md`: implementationsplan, blockerad av öppna frågor.


### PR DESCRIPTION
### Motivation

- Break the monolithic simulation specification into clear, reviewable domain descriptions to separate responsibilities and surface open questions. 
- Capture observed behavior from the codebase as durable specification artifacts to guide future design and implementation decisions.

### Description

- Added a domain index `specs/domains/README.md` and five domain documents: `world-structure.md`, `ownership-and-authority.md`, `population-and-economy.md`, `time-weather-and-events.md`, and `people-and-households.md`, each describing scope, rules, boundaries and quality notes. 
- Updated the shared domain overview `specs/domains/simulation.md` to reference the new domain files and bumped the last-checked date. 
- Recorded the new documents as active spec artifacts in `specs/status/SPECSTATUS.md` and appended changelog entries in `specs/domains/simulation.Changelog.md`, `specs/status/SPECSTATUS.Changelog.md`, and `specs/evidence/source-inventory.Changelog.md`. 
- Extended `specs/evidence/source-inventory.md` with additional code modules examined as supporting evidence for the domain split.

### Testing

- Ran the full Python test suite with `pytest -q`, which completed successfully: 454 passed, 115 skipped, overall coverage 89.05%. 
- Validated domain Markdown structure and required `## Historik` footers with a short Python check, which passed. 
- Ran `git diff --check` and local repository status checks to ensure no whitespace or diff issues remained, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7c1e6c17488330a0d0e24541ad2f1b)