### PR TITLE
docs: mark HTTP listener and C++ experiment as non-production; add client-boundaries decision

### DIFF
--- a/specs/architecture/system-overview.Changelog.md
+++ b/specs/architecture/system-overview.Changelog.md
@@ -1,3 +1,4 @@
 # Systemöversikt: arkitektur – historik
 
+- 2026-08-12: Avgränsade Python/Tk som huvudlösning, klassade HTTP och C++/SDL2 som experiment och skilde dem från en framtida webbfrontend.
 - 2026-08-11: Korrigerade aktiv tidsmotor och lade till provins-, rollup- och relationsgränser från kodanalysen.

--- a/specs/architecture/system-overview.md
+++ b/specs/architecture/system-overview.md
@@ -3,7 +3,8 @@
 ## Syfte och omfattning
 
 Dokumentet beskriver nuvarande huvudgränser utan att föreskriva ändringar i
-server, datakontrakt, `world_manager` eller admin-läge.
+datakontrakt, `world_manager` eller admin-läge. Den primära lösningen är
+Python-/Tk-applikationen.
 
 ## Systemgränser och komponenter
 
@@ -21,10 +22,13 @@ server, datakontrakt, `world_manager` eller admin-läge.
 - `src/world_relations.py` är en domänadapter för validering samt atomära läs-
   och skrivoperationer för titel–säte och jarldöme–ägare. Detaljvyn använder
   en separat presentationsadapter och visar relationerna skrivskyddat.
-- `src/http_server.py` erbjuder en minimal HTML-presentation vid sidan av
-  Tk-klienten.
-- `src2/` är ett separat experiment i C++/SDL2 och ingår inte i den primära
-  Python-applikationens körväg.
+- `src/http_server.py` är en bevarad experimentell HTTP-presentation. Den är
+  inte längre i bruk och ingår inte i den primära lösningens körväg.
+- `src2/` är ett bevarat experiment i C++/SDL2. Det är inte i bruk och ingår
+  inte i den primära Python-lösningen.
+- En framtida faktisk webbfrontend är en möjlig separat klient, men dess
+  omfattning, teknik och gränssnitt är ännu inte beslutade. Den befintliga
+  HTTP-listenern ska inte betraktas som dess grund eller som aktiv frontend.
 
 ## Gränssnitt och dataflöden
 
@@ -47,10 +51,12 @@ Personlig provinslogik kompletterar den administrativa nodhierarkin för
   inte dubbelräknas vid rekursiv traversering.
 - Relationer ska valideras utan mutation; skrivoperationer får mutera först
   när hela den begärda relationen är giltig.
+- Experimenten i `src/http_server.py` och `src2/` får inte behandlas som
+  produktionsberoenden eller begränsa utformningen av en framtida webbklient.
 
 ## Kopplade beslut och underlag
 
-- Beslut: inga formella beslutsposter ännu.
+- Beslut: `../decisions/2026-08-12-client-boundaries.md`.
 - Underlag: `../evidence/source-inventory.md`.
 - Domänregler: `../domains/simulation.md`.
 

--- a/specs/decisions/2026-08-12-client-boundaries.Changelog.md
+++ b/specs/decisions/2026-08-12-client-boundaries.Changelog.md
@@ -1,0 +1,3 @@
+# Klientgränser och experimentell kod – historik
+
+- 2026-08-12: Dokumenterade huvudlösningens klientgräns och sköt upp beslutet om en faktisk webbfrontend.

--- a/specs/decisions/2026-08-12-client-boundaries.md
+++ b/specs/decisions/2026-08-12-client-boundaries.md
@@ -1,0 +1,54 @@
+# Beslut: klientgränser och experimentell kod
+
+- Datum: 2026-08-12
+- Status: `ACCEPTED`
+
+## Kontext
+
+Repot innehåller den primära Python-/Tk-applikationen, ett C++/SDL2-spår och
+en minimal HTTP-listener i Python. Förekomsten av de två senare har gjort det
+otydligt vilka klienter som ingår i vår aktiva lösning. Samtidigt finns en
+framtida ambition att överväga en faktisk webbfrontend som efterliknar
+applikationens funktionalitet.
+
+## Beslut
+
+Python-/Tk-applikationen är huvudlösningen och den enda klienten i bruk.
+C++/SDL2-koden under `src2/` och HTTP-listenern i `src/http_server.py` bevaras
+som experimentell, ej använd kod och ingår inte i huvudlösningen.
+
+En faktisk webbfrontend kan utvecklas senare, men funktionsomfattning,
+arkitektur, teknik och prioritet kräver ett separat framtida beslut. Den
+befintliga HTTP-listenern är varken en aktiv webbfrontend eller ett på förhand
+valt fundament för den framtida lösningen.
+
+## Övervägda alternativ
+
+- Behandla samtliga tre körvägar som aktiva klienter: avvisat eftersom det
+  felaktigt beskriver faktisk användning och skapar oavsiktliga
+  underhållskrav.
+- Göra HTTP-listenern till grund för nästa webbfrontend: inte beslutat;
+  framtida behov och arkitektur ska utvärderas utan den premissen.
+- Ta bort experimentkoden nu: inte valt; beslutet klassificerar ansvar och
+  användning men föreskriver ingen produktionsändring i spec-läge.
+
+## Konsekvenser
+
+- Krav och planer ska inte räkna C++/SDL2 eller HTTP-listenern som aktiva
+  produktgränssnitt.
+- Experimentkoden skapar inga kompatibilitetskrav för huvudlösningen.
+- Webbfrontenden ligger kvar som en uttryckligen uppskjuten fråga och får inte
+  smygimplementeras genom att vidareutveckla den gamla listenern utan beslut.
+- Eventuell senare borttagning eller arkivering av experimentkoden kräver en
+  separat implementationsåtgärd.
+
+## Länkar
+
+- Arkitektur: `../architecture/system-overview.md`.
+- Domän: `../domains/simulation.md`.
+- Underlag: `../evidence/source-inventory.md`.
+- Plan: `../plans/product-plan.md`.
+
+## Historik
+
+- Ändringshistorik finns i `2026-08-12-client-boundaries.Changelog.md`.

--- a/specs/decisions/README.Changelog.md
+++ b/specs/decisions/README.Changelog.md
@@ -1,0 +1,3 @@
+# Beslut – historik
+
+- 2026-08-12: Lade till den första beslutsposten om aktiva och experimentella klienter.

--- a/specs/decisions/README.md
+++ b/specs/decisions/README.md
@@ -1,9 +1,15 @@
 # Beslut
 
-Här sparas framtida beslutsposter med datum, status, valt alternativ, kontext,
-alternativ, konsekvenser och länkat underlag. Inga produktbeslut har antagits i
-den första konverteringen; öppna val finns i `../domains/simulation.md`.
+Här sparas beslutsposter med datum, status, valt alternativ, kontext,
+alternativ, konsekvenser och länkat underlag. Öppna val finns i
+`../domains/simulation.md`.
+
+## Beslutsposter
+
+- `2026-08-12-client-boundaries.md`: Python/Tk är huvudlösningen; C++/SDL2 och
+  HTTP-listenern är experimentella och inte i bruk, medan en faktisk
+  webbfrontend avgränsas genom ett senare beslut.
 
 ## Historik
 
-- Ändringar kommer att sparas i `README.Changelog.md`.
+- Ändringshistorik finns i `README.Changelog.md`.

--- a/specs/domains/simulation.Changelog.md
+++ b/specs/domains/simulation.Changelog.md
@@ -1,3 +1,4 @@
 # Feodal simulering: verksamhetsbeskrivning och regler – historik
 
+- 2026-08-12: Klargjorde att Python/Tk är i bruk, att HTTP och C++/SDL2 är experiment samt att en faktisk webbfrontend beslutas senare.
 - 2026-08-11: Synkroniserade tids-, provins-, sammanräknings- och relationsregler med implementerad kod.

--- a/specs/domains/simulation.md
+++ b/specs/domains/simulation.md
@@ -3,8 +3,8 @@
 ## Syfte
 
 Simulatorn ska beskriva en feodal värld där hierarkiska förläningar och deras
-lokala resurser kan granskas och förändras över tid. Tk-gränssnittet är den
-primära klienten; ett enklare HTTP-gränssnitt visar samma typ av data.
+lokala resurser kan granskas och förändras över tid. Tk-gränssnittet i Python
+är den primära och enda klienten i bruk.
 
 ## Begrepp
 
@@ -34,8 +34,9 @@ primära klienten; ett enklare HTTP-gränssnitt visar samma typ av data.
    Tk-klienten.
 5. Administrativ väg och personlig provinsväg har skilda ansvar; provinsvägen
    styr skatt enligt den befintliga Modell B-beskrivningen.
-6. Tk-klienten erbjuder struktur-, status- och detaljpaneler. HTTP-servern är
-   ett separat, enklare presentationsgränssnitt.
+6. Tk-klienten erbjuder struktur-, status- och detaljpaneler. Den befintliga
+   HTTP-listenern är ett äldre experiment som inte längre används. Även
+   C++/SDL2-koden är experimentell, inte i bruk och utanför huvudlösningen.
 7. Provinsläget visar ägarens ankare och bygger därefter hela trädet från
    `get_province_subtree(owner_id)` med rekursiv insert. En explicit ägare på
    en undernod bryter nedärvningen från en överordnad ägare; adminträdet har en
@@ -55,6 +56,9 @@ primära klienten; ett enklare HTTP-gränssnitt visar samma typ av data.
 - Händelser på flera geografiska och hierarkiska nivåer.
 - Förgrening eller regenerering av framtiden efter ändringar bakåt i tiden.
 - Kart-, tidslinje- och förändringsvisualisering.
+- En faktisk webbfrontend som efterliknar relevant funktionalitet i
+  applikationen. Omfattning, teknik och prioritet beslutas senare; den
+  befintliga HTTP-listenern är inte den beslutade webbfrontenden.
 
 Dessa punkter är kandidater, inte bekräftade implementationskrav.
 
@@ -75,10 +79,12 @@ Dessa punkter är kandidater, inte bekräftade implementationskrav.
 - [ ] Vilka händelser och relationer måste ingå i första kompletta simuleringen?
 - [ ] Ska de explicita titel- och ägarrelationerna förbli endast läsbara i UI,
   eller ska ett framtida icke-adminflöde få redigera dem?
+- [ ] Vilken funktionalitet, arkitektur och prioritet ska en framtida faktisk
+  webbfrontend få när webbspåret tas upp för beslut?
 
 ## Kvalitetskontroll
 
-Senast kontrollerad: 2026-08-11
+Senast kontrollerad: 2026-08-12
 
 ### Motsägelser
 
@@ -96,6 +102,8 @@ Senast kontrollerad: 2026-08-11
 ### Otydliga beskrivningar
 
 - Omfattningen av handel, politik, krig och allianser är inte specificerad.
+- "Efterlikna applikationens funktionalitet" saknar ännu beslutad
+  funktionsmängd och acceptanskriterier för en framtida webbfrontend.
 
 ### Glapp i resonemang
 

--- a/specs/evidence/source-inventory.Changelog.md
+++ b/specs/evidence/source-inventory.Changelog.md
@@ -1,3 +1,4 @@
 # Källinventering: underlag – historik
 
+- 2026-08-12: Kompletterade inventeringen med HTTP-listenern och C++/SDL2-experimentet samt skilde kodförekomst från produktstatus.
 - 2026-08-11: Utökade underlaget med aktiv tidskörväg, provinsrendering, rollup-policy och världsrelationer.

--- a/specs/evidence/source-inventory.md
+++ b/specs/evidence/source-inventory.md
@@ -23,10 +23,18 @@ strukturerade specifikationsuppsättningen.
 - `src/rollup_policy.py`, `src/world_relations.py` och deras tester (lästa
   2026-08-11): bekräftar lokala bidragspolicyer samt explicita, validerade
   titel–säte- och jarldöme–ägare-relationer.
+- `src/http_server.py` och `tests/test_http_server.py` (granskade 2026-08-12):
+  visar en fristående minimal WSGI-listener. Produktbeslutet klassar den som
+  ett bevarat experiment som inte längre används, oavsett att tester finns.
+- `src2/Main.cpp` och `src2/Makefile` (granskade 2026-08-12): visar ett separat
+  SDL2-experiment. Produktbeslutet placerar all C++-kod utanför den primära
+  Python-lösningen och markerar den som inte i bruk.
 
 ## Tolkning och begränsningar
 
 Inventeringen är en riktad kodanalys, inte en fullständig rad-för-rad-revision.
+Att kod eller tester finns kvar är inte i sig bevis för att komponenten är i
+bruk; aktuell produktstatus styrs av länkade beslut.
 Visionens framtidsidéer har inte automatiskt gjorts till krav. Nya beslut ska
 spåras i `specs/decisions/` i stället för att skrivas tillbaka till visionen.
 
@@ -35,6 +43,7 @@ spåras i `specs/decisions/` i stället för att skrivas tillbaka till visionen.
 - Krav: `../domains/simulation.md`.
 - Arkitektur: `../architecture/system-overview.md`.
 - Plan: `../plans/product-plan.md`.
+- Beslut: `../decisions/2026-08-12-client-boundaries.md`.
 
 ## Historik
 

--- a/specs/plans/product-plan.Changelog.md
+++ b/specs/plans/product-plan.Changelog.md
@@ -1,4 +1,5 @@
 # Feodal simulering: implementationsplan – historik
 
+- 2026-08-12: Lade till en uppskjuten åtgärd för separat beslut om en faktisk webbfrontend.
 - 2026-08-11: Lade till beslutspunkt för relationsbegrepp och skrivskyddat UI efter kodanalys.
 - 2026-08-11: Skapade första prioriterade planutkastet från strukturerade specifikationer.

--- a/specs/plans/product-plan.md
+++ b/specs/plans/product-plan.md
@@ -8,7 +8,7 @@ nya produktionsändringar planeras.
 ## Statusöversikt
 
 - Total status: `BLOCKED`
-- Senast uppdaterad: 2026-08-11
+- Senast uppdaterad: 2026-08-12
 - Blocker: öppna produktfrågor i `../domains/simulation.md`.
 
 ## Prioritetsgrupper
@@ -48,6 +48,14 @@ nya produktionsändringar planeras.
      tester.
    - Blocker: P0 och relevanta P1-punkter måste vara lösta.
    - Kopplad specifikation: `../domains/simulation.md`.
+2. [DEFERRED] WEB-001 Besluta om faktisk webbfrontend
+   - Beskrivning: besluta funktionsomfattning, arkitektur, kontrakt och
+     acceptanskriterier för en webbklient som efterliknar relevant
+     Tk-funktionalitet.
+   - Blocker: webbspåret är uttryckligen ett senare beslut. Den experimentella
+     HTTP-listenern är inte en aktiv frontend eller förvald grund.
+   - Kopplad specifikation: `../architecture/system-overview.md` och
+     `../decisions/2026-08-12-client-boundaries.md`.
 
 ## Historik
 

--- a/specs/status/SPECSTATUS.Changelog.md
+++ b/specs/status/SPECSTATUS.Changelog.md
@@ -1,4 +1,5 @@
 # Specifikationsstatus: historik
 
+- 2026-08-12: Registrerade experimentella klientspår och den uppskjutna webbfrontendfrågan.
 - 2026-08-11: Synkroniserade levande specifikationer med aktiv kod och skapade en prioriterad frågelista.
 - 2026-08-11: Initierade strukturerad specmapp i SPEC-läge från uttrycklig begäran.

--- a/specs/status/SPECSTATUS.md
+++ b/specs/status/SPECSTATUS.md
@@ -3,7 +3,7 @@
 - Sticky specmapp: `specs/`
 - Repostatus: `SPEC`
 - Uppstartsnivå: `STRUCTURED`
-- Senast uppdaterad: 2026-08-11
+- Senast uppdaterad: 2026-08-12
 
 ## Levande dokument
 
@@ -21,6 +21,13 @@
 - Prioritering och avgränsning av ekonomi, händelser och relationer.
 - UI-ansvar och terminologi för explicita titel-/ägarrelationer jämfört med
   personlig provinstilldelning.
+- Senare avgränsning och arkitektur för en faktisk webbfrontend.
+
+## Fastställda klientgränser
+
+- Python/Tk är huvudlösningen och den enda klienten i bruk.
+- Befintlig HTTP-listener och C++/SDL2-kod är bevarade experiment utanför
+  huvudlösningen; se `../decisions/2026-08-12-client-boundaries.md`.
 
 ## MCP-stöd
 

--- a/specs/status/outstanding-questions.Changelog.md
+++ b/specs/status/outstanding-questions.Changelog.md
@@ -1,0 +1,3 @@
+# Kvarstående specifikationsfrågor – historik
+
+- 2026-08-12: Lade till den avsiktligt uppskjutna frågan om en faktisk webbfrontend.

--- a/specs/status/outstanding-questions.md
+++ b/specs/status/outstanding-questions.md
@@ -16,6 +16,13 @@
 3. Hur ska termen "ägare" namnges i krav och UI så att personlig
    provinstilldelning inte sammanblandas med jarldömets personrelation?
 
+## P2 – avsiktligt senare beslut
+
+1. Vilken del av Tk-applikationens funktionalitet ska en framtida faktisk
+   webbfrontend efterlikna, och vilka arkitektur- och teknikval ska då gälla?
+   Den befintliga experimentella HTTP-listenern är inte i bruk och utgör
+   inget beslutat utgångsläge.
+
 ## Historik
 
 - Ändringar kommer att sparas i `outstanding-questions.Changelog.md`.


### PR DESCRIPTION
### Motivation

- Clarify which client code paths are part of the active product and which are retained experiments so plans, requirements and future web work are not based on obsolete listeners or experimental C++ code. 
- Record an explicit, deferred decision that a real web frontend is a separate future project and must be scoped independently. 

### Description

- Marked the Python HTTP listener (`src/http_server.py`) and the C++/SDL2 experiment (`src2/`) as preserved experiments and not part of the primary Python/Tk solution across architecture, domain, evidence and status specs. 
- Added an explicit decision document `specs/decisions/2026-08-12-client-boundaries.md` that declares Python/Tk as the single active client and classifies the HTTP listener and C++ experiment as non-production. 
- Updated `specs/architecture/system-overview.md`, `specs/domains/simulation.md`, `specs/evidence/source-inventory.md`, `specs/plans/product-plan.md`, `specs/status/SPECSTATUS.md`, and `specs/status/outstanding-questions.md` to reflect the client boundaries and to add a deferred P2 plan item for deciding a future web frontend; added matching changelog entries. 

### Testing

- Ran the full test suite with `pytest`: 454 passed, 115 skipped and total coverage ~89%, satisfying the coverage gate. 
- Ran repository checks including `git diff --check` and a script that validated the required specification history/footer entries, all of which passed. 
- Confirmed the working tree was clean after the documentation updates and that the new decision and changelog files are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7c1f1f6b0c833087f6e128329361e5)