### PR TITLE
Specify a clean, replaceable UI application boundary

### DIFF
--- a/specs/README.Changelog.md
+++ b/specs/README.Changelog.md
@@ -1,0 +1,3 @@
+# Specifikationer – historik
+
+- 2026-08-12: Lade till UI-gränsen i kartan över levande specifikationer.

--- a/specs/README.md
+++ b/specs/README.md
@@ -9,6 +9,8 @@ men skiljer bekräftade nulägeskrav från framtida idéer.
 - `domains/README.md`: karta över identifierade verksamhetsdomäner.
 - `domains/simulation.md`: gemensam verksamhetsbeskrivning, begrepp och regler.
 - `architecture/system-overview.md`: systemgränser och huvudkomponenter.
+- `architecture/ui-boundary.md`: UI som adapter samt kontrakt för rena,
+  testbara dataflöden till och från presentationen.
 - `plans/product-plan.md`: prioriterade specifikations- och införandeåtgärder.
 - `status/SPECSTATUS.md`: aktuell repostatus, öppna frågor och levande dokument.
 - `status/outstanding-questions.md`: prioriterade kvarstående
@@ -34,4 +36,4 @@ men skiljer bekräftade nulägeskrav från framtida idéer.
 
 ## Historik
 
-- Ändringar kommer att sparas i `README.Changelog.md`.
+- Ändringshistorik finns i `README.Changelog.md`.

--- a/specs/architecture/system-overview.Changelog.md
+++ b/specs/architecture/system-overview.Changelog.md
@@ -1,4 +1,5 @@
 # Systemöversikt: arkitektur – historik
 
+- 2026-08-12: Länkade målarkitekturen där UI är en utbytbar adapter till en headless-testbar applikationsgräns.
 - 2026-08-12: Avgränsade Python/Tk som huvudlösning, klassade HTTP och C++/SDL2 som experiment och skilde dem från en framtida webbfrontend.
 - 2026-08-11: Korrigerade aktiv tidsmotor och lade till provins-, rollup- och relationsgränser från kodanalysen.

--- a/specs/architecture/system-overview.md
+++ b/specs/architecture/system-overview.md
@@ -11,6 +11,10 @@ Python-/Tk-applikationen.
 - `src/Feudal.py` startar Tk-applikationen.
 - UI- och presentationsmoduler under `src/` visar struktur, status, detaljer
   och kartvyer.
+- UI:t är målarkitekturellt en utbytbar presentationsadapter, inte en
+  verksamhetsdomän. Teknikneutrala frågor och kommandon ska passera den
+  applikationsgräns som beskrivs i `ui-boundary.md`; dagens direkta kopplingar
+  till managers och muterbar världsdata ska migreras stegvis.
 - Domänmoduler hanterar noder, resurser, befolkning, personliga provinser,
   väder och relationer.
 - `src/time/time_engine.py` är Tk-klientens aktiva årsbaserade tidsmotor och
@@ -45,6 +49,8 @@ Personlig provinslogik kompletterar den administrativa nodhierarkin för
 - Tidigare snapshots ska vara oföränderliga ur användarflödets perspektiv.
 - Domänlogik ska kunna testas utan ett grafiskt fönster; UI-test ska kunna
   hoppas över i headless-miljö.
+- Applikationsanvändningsfall ska kunna testas headless och får inte exponera
+  Tk-typer, widgethändelser, domänobjekt eller levande muterbara samlingar.
 - Admin-läge och den administrativa hierarkin får inte påverkas oavsiktligt av
   provinslägets presentationsväg.
 - Rapportvärden ska räknas från lokala bidrag så att redan aggregerade värden
@@ -57,6 +63,8 @@ Personlig provinslogik kompletterar den administrativa nodhierarkin för
 ## Kopplade beslut och underlag
 
 - Beslut: `../decisions/2026-08-12-client-boundaries.md`.
+- Beslut: `../decisions/2026-08-12-ui-as-adapter.md`.
+- UI-gräns: `ui-boundary.md`.
 - Underlag: `../evidence/source-inventory.md`.
 - Domänregler: `../domains/simulation.md`.
 

--- a/specs/architecture/ui-boundary.Changelog.md
+++ b/specs/architecture/ui-boundary.Changelog.md
@@ -1,0 +1,3 @@
+# UI-gräns och applikationskontrakt – historik
+
+- 2026-08-12: Fastställde UI som presentationsadapter samt kontrakts-, beroende-, test- och migreringsprinciper.

--- a/specs/architecture/ui-boundary.md
+++ b/specs/architecture/ui-boundary.md
@@ -1,0 +1,121 @@
+# UI-gräns och applikationskontrakt
+
+## Syfte
+
+Användargränssnittet är en utbytbar presentationsadapter till simuleringen.
+Det är inte en egen verksamhetsdomän: Tk, en framtida webbklient och testkod
+ska använda samma applikationsgräns utan att domänregler flyttas in i en viss
+presentationsteknik.
+
+Detta dokument anger målarkitekturen. Nuvarande Tk-kod får migreras stegvis;
+att den i dag anropar domänobjekt och delar muterbara datastrukturer direkt
+gör inte kopplingen till ett godkänt kontrakt.
+
+## Ansvarsgränser
+
+### Presentation
+
+UI-adaptern ansvarar för widgetar, layout, navigering, lokalt visningstillstånd,
+inmatningsinsamling, formatering och översättning av ett svar till en vy. Den
+får validera presentationsdetaljer, exempelvis att ett obligatoriskt fält inte
+är tomt, men äger inga simuleringsregler.
+
+### Applikationsgräns
+
+Applikationslagret exponerar användningsfall som teknikneutrala frågor och
+kommandon. Det samordnar domäntjänster, transaktioner och beständighet samt
+översätter domänresultat till kontraktsdata. Det är den enda ordinarie vägen
+för en UI-adapter att läsa eller ändra simuleringen.
+
+### Domän och infrastruktur
+
+Domänen äger regler, beräkningar och invariants. Infrastruktur äger bland
+annat filåtkomst och beständighet bakom portar som applikationslagret använder.
+Inget av lagren får importera Tk eller känna till widgetar, dialoger eller
+presentationshändelser.
+
+## Dataflöden
+
+### Läsning
+
+1. UI:t skickar en fråga med enkla kontraktsvärden, exempelvis ett nod-id.
+2. Applikationslagret läser och beräknar via domänen.
+3. UI:t får en frikopplad, skrivskyddad snapshot/DTO av de fält som
+   användningsfallet behöver.
+4. UI:t renderar svaret utan att behålla en muterbar referens till
+   domänmodellen.
+
+### Ändring
+
+1. UI:t skapar ett uttryckligt kommando av användarens avsikt.
+2. Applikationslagret validerar behörigt användningsfall och låter domänen
+   upprätthålla reglerna.
+3. Resultatet är ett uttryckligt lyckat svar eller ett teknikneutralt fel med
+   stabil kod och relevanta fältdetaljer.
+4. UI:t väljer hur resultatet presenteras och begär vid behov en ny snapshot.
+
+UI:t får inte mutera delade världs-dictionaries, anropa sparning som en
+biverkan av rendering eller använda Tk-callbackar som applikationskontrakt.
+
+## Kontraktsregler
+
+- Gränsen består av namngivna frågor, kommandon, svar och fel; den exponerar
+  inte `tkinter`-typer, widgetar eller UI-klasser.
+- Kontraktsdata innehåller endast serialiserbara värden, stabila identifierare
+  och uttryckligt definierade sammansättningar. Domänobjekt och levande
+  muterbara samlingar lämnas inte till klienten.
+- Varje kommando beskriver en användaravsikt, inte en widgethändelse. Exempel:
+  `AdvanceTime` är tillåtet medan `OnNextButtonClick` inte är det.
+- Frågor saknar domänmutation. Kommandon får inte kräva att klienten först
+  ändrar intern världsdata.
+- Domän- och applikationsfel översätts vid gränsen. Dialogtext och annan
+  presentationstext tillhör UI-adaptern.
+- Kontrakt ska kunna versionshanteras eller utökas additivt när fler klienter
+  tillkommer. Interna Python-klasser är inte automatiskt publika kontrakt.
+- Samma kontrakt ska kunna anropas synkront in-process av Tk och senare
+  placeras bakom en transportadapter utan att domänens användningsfall skrivs
+  om. Ingen nätverkstransport beslutas här.
+
+## Beroenderiktning
+
+`Tk-adapter -> applikationsport -> domän`
+
+Beständighet och andra tekniska integrationer implementerar portar riktade
+inåt. En framtida UI-implementation ersätter eller kompletterar Tk-adaptern;
+den får inte skapa en parallell uppsättning domänregler.
+
+## Testbarhetskrav
+
+- Applikationsfrågor och kommandon ska kunna testas utan Tk-root, display eller
+  en körande eventloop.
+- Kontraktstester ska verifiera indata, svar, felkoder och att snapshots inte
+  ger klienten en mutationsväg tillbaka till domäntillståndet.
+- Domänregler testas under applikationsgränsen och UI-adaptern testas separat
+  med testdubblar för porten.
+- En ny UI-adapter ska kunna återanvända samma kontraktstester. Endast
+  adaptertester ska vara teknikberoende.
+- Ett användningsfall räknas inte som frikopplat förrän dess Tk-kod saknar
+  direkt åtkomst till muterbar världsdata och domänens konkreta managers.
+
+## Migreringsprincip
+
+Gränsen införs vertikalt, ett användningsfall i taget. För varje flöde
+identifierar vi först fråga/kommando och svar, lägger kontrakts- och
+applikationstester under gränsen och flyttar därefter Tk-koden till en tunn
+adapter. En stor omskrivning av hela UI:t är varken nödvändig eller önskad.
+
+Exakta första användningsfall och kontraktsformer beslutas före implementation.
+JRDL eller annat transportformat behövs först när vi vill göra kontraktet
+språk- eller processöverskridande; Python-typer kan räcka för den första
+in-process-gränsen.
+
+## Kopplade dokument
+
+- Beslut: `../decisions/2026-08-12-ui-as-adapter.md`.
+- Systemöversikt: `system-overview.md`.
+- Klientgränser: `../decisions/2026-08-12-client-boundaries.md`.
+- Plan: `../plans/product-plan.md`.
+
+## Historik
+
+- Ändringshistorik finns i `ui-boundary.Changelog.md`.

--- a/specs/decisions/2026-08-12-ui-as-adapter.Changelog.md
+++ b/specs/decisions/2026-08-12-ui-as-adapter.Changelog.md
@@ -1,0 +1,3 @@
+# Beslut: UI som presentationsadapter – historik
+
+- 2026-08-12: Accepterade en teknikneutral applikationsgräns i stället för UI som verksamhetsdomän.

--- a/specs/decisions/2026-08-12-ui-as-adapter.md
+++ b/specs/decisions/2026-08-12-ui-as-adapter.md
@@ -1,0 +1,55 @@
+# Beslut: UI som presentationsadapter
+
+- Datum: 2026-08-12
+- Status: `ACCEPTED`
+
+## Kontext
+
+Tk-applikationen är vår enda aktiva klient, men delar av presentationen har
+direkt åtkomst till konkreta managers och muterbar världsdata. Det försvårar
+headless-testning och gör ett framtida byte av presentationsteknik dyrt.
+
+Att kalla UI:t en egen verksamhetsdomän skulle samtidigt blanda teknisk
+presentation med simuleringens verksamhetsbegrepp. Behovet är i stället en
+tydlig arkitekturgräns runt användningsfallen.
+
+## Beslut
+
+UI behandlas som en separat presentationsadapter, inte som en
+verksamhetsdomän. Tk och möjliga framtida klienter ska bero på en
+teknikneutral applikationsport med uttryckliga frågor, kommandon, snapshots
+och fel. Domän- och infrastrukturlager får inte bero på UI-teknik.
+
+Gränsen införs stegvis per användningsfall och specificeras i
+`../architecture/ui-boundary.md`.
+
+## Övervägda alternativ
+
+- **UI som egen verksamhetsdomän:** avvisat eftersom widgetar, navigering och
+  presentation inte utgör simuleringens verksamhetsregler.
+- **Fortsatt direkt Tk–domänkoppling:** avvisat eftersom delad muterbar data
+  och konkreta managers ger svårisolerade tester och klientinlåsning.
+- **Nätverks-API som obligatorisk gräns:** avvisat nu; en in-process-port ger
+  separation utan distributionskomplexitet och kan senare transportanpassas.
+- **Full omskrivning före fortsatt arbete:** avvisat till förmån för vertikal,
+  testdriven migrering av ett användningsfall i taget.
+
+## Konsekvenser
+
+- Nya UI-flöden ska inte introducera direkt mutation av världsdata.
+- Applikationskontrakt och domänbeteende kan testas headless; Tk testas som en
+  separat adapter.
+- Ett framtida UI-byte återanvänder användningsfallen men kräver en ny adapter.
+- Nuvarande kopplingar är migreringsskuld, inte prejudikat för nya kontrakt.
+- Första migreringsflöde och exakt Python-kontraktsform återstår att välja.
+
+## Länkar
+
+- Arkitektur: `../architecture/ui-boundary.md`.
+- Systemöversikt: `../architecture/system-overview.md`.
+- Plan: `../plans/product-plan.md`.
+- Status: `../status/outstanding-questions.md`.
+
+## Historik
+
+- Ändringshistorik finns i `2026-08-12-ui-as-adapter.Changelog.md`.

--- a/specs/decisions/README.Changelog.md
+++ b/specs/decisions/README.Changelog.md
@@ -1,3 +1,4 @@
 # Beslut – historik
 
+- 2026-08-12: Registrerade beslutet att behandla UI som adapter till applikationsgränsen.
 - 2026-08-12: Lade till den första beslutsposten om aktiva och experimentella klienter.

--- a/specs/decisions/README.md
+++ b/specs/decisions/README.md
@@ -9,6 +9,8 @@ alternativ, konsekvenser och länkat underlag. Öppna val finns i
 - `2026-08-12-client-boundaries.md`: Python/Tk är huvudlösningen; C++/SDL2 och
   HTTP-listenern är experimentella och inte i bruk, medan en faktisk
   webbfrontend avgränsas genom ett senare beslut.
+- `2026-08-12-ui-as-adapter.md`: UI är en utbytbar presentationsadapter till
+  en teknikneutral, headless-testbar applikationsgräns.
 
 ## Historik
 

--- a/specs/plans/product-plan.Changelog.md
+++ b/specs/plans/product-plan.Changelog.md
@@ -1,5 +1,6 @@
 # Feodal simulering: implementationsplan – historik
 
+- 2026-08-12: Lade till uppskjuten, vertikal introduktion av den beslutade UI-/applikationsgränsen.
 - 2026-08-12: Lade till en uppskjuten åtgärd för separat beslut om en faktisk webbfrontend.
 - 2026-08-11: Lade till beslutspunkt för relationsbegrepp och skrivskyddat UI efter kodanalys.
 - 2026-08-11: Skapade första prioriterade planutkastet från strukturerade specifikationer.

--- a/specs/plans/product-plan.md
+++ b/specs/plans/product-plan.md
@@ -43,12 +43,19 @@ nya produktionsändringar planeras.
 
 ### P2 - Implementation
 
-1. [DEFERRED] IMPL-001 Skapa kodnära genomförandeplan
+1. [DEFERRED] UI-001 Inför applikationsgränsen vertikalt
+   - Beskrivning: välj ett avgränsat användningsfall, definiera fråga eller
+     kommando med snapshot/fel, lägg headless kontrakts- och
+     applikationstester och gör Tk-flödet till en tunn adapter.
+   - Blocker: första flöde och Python-kontraktsform ska beslutas; repot är i
+     `SPEC` och produktionskod får inte ändras.
+   - Kopplad specifikation: `../architecture/ui-boundary.md`.
+2. [DEFERRED] IMPL-001 Skapa kodnära genomförandeplan
    - Beskrivning: bryt ned endast beslutade krav i små ändringar och fokuserade
      tester.
    - Blocker: P0 och relevanta P1-punkter måste vara lösta.
    - Kopplad specifikation: `../domains/simulation.md`.
-2. [DEFERRED] WEB-001 Besluta om faktisk webbfrontend
+3. [DEFERRED] WEB-001 Besluta om faktisk webbfrontend
    - Beskrivning: besluta funktionsomfattning, arkitektur, kontrakt och
      acceptanskriterier för en webbklient som efterliknar relevant
      Tk-funktionalitet.

--- a/specs/status/SPECSTATUS.Changelog.md
+++ b/specs/status/SPECSTATUS.Changelog.md
@@ -1,5 +1,6 @@
 # Specifikationsstatus: historik
 
+- 2026-08-12: Registrerade beslutet att behandla UI som adapter till en teknikneutral applikationsgräns.
 - 2026-08-12: Registrerade experimentella klientspår och den uppskjutna webbfrontendfrågan.
 - 2026-08-12: Registrerade domänkartan och fem fördjupade domänbeskrivningar som levande dokument.
 - 2026-08-11: Synkroniserade levande specifikationer med aktiv kod och skapade en prioriterad frågelista.

--- a/specs/status/SPECSTATUS.md
+++ b/specs/status/SPECSTATUS.md
@@ -12,6 +12,8 @@
 - `specs/domains/*.md`: fördjupningar av världsstruktur, ägande och auktoritet,
   befolkning och ekonomi, tid/väder/händelser samt personer och hushåll.
 - `specs/architecture/system-overview.md`: arkitekturöversikt, första utgåva.
+- `specs/architecture/ui-boundary.md`: beslutad målgräns mellan utbytbar UI-
+  adapter, applikationsanvändningsfall och domän.
 - `specs/evidence/source-inventory.md`: källunderlag, första utgåva.
 - `specs/plans/product-plan.md`: implementationsplan, blockerad av öppna frågor.
 - `specs/status/outstanding-questions.md`: prioriterade kvarstående
@@ -25,12 +27,16 @@
 - UI-ansvar och terminologi för explicita titel-/ägarrelationer jämfört med
   personlig provinstilldelning.
 - Senare avgränsning och arkitektur för en faktisk webbfrontend.
+- Första användningsfall och exakt Python-kontraktsform för UI-migreringen.
 
 ## Fastställda klientgränser
 
 - Python/Tk är huvudlösningen och den enda klienten i bruk.
 - Befintlig HTTP-listener och C++/SDL2-kod är bevarade experiment utanför
   huvudlösningen; se `../decisions/2026-08-12-client-boundaries.md`.
+- UI är en presentationsadapter, inte en verksamhetsdomän. Tk ska stegvis
+  flyttas bakom en teknikneutral och headless-testbar applikationsport; se
+  `../decisions/2026-08-12-ui-as-adapter.md`.
 
 ## MCP-stöd
 

--- a/specs/status/outstanding-questions.Changelog.md
+++ b/specs/status/outstanding-questions.Changelog.md
@@ -1,3 +1,3 @@
 # Kvarstående specifikationsfrågor – historik
 
-- 2026-08-12: Lade till den avsiktligt uppskjutna frågan om en faktisk webbfrontend.
+- 2026-08-12: Lade till val av första UI-migreringsflöde och Python-kontraktsform.

--- a/specs/status/outstanding-questions.md
+++ b/specs/status/outstanding-questions.md
@@ -18,11 +18,14 @@
 
 ## P2 – avsiktligt senare beslut
 
-1. Vilken del av Tk-applikationens funktionalitet ska en framtida faktisk
+1. Vilket avgränsat Tk-användningsfall ska migreras först bakom
+   applikationsporten, och ska det första in-process-kontraktet uttryckas med
+   frysta dataklasser, protokoll eller annan enkel Python-form?
+2. Vilken del av Tk-applikationens funktionalitet ska en framtida faktisk
    webbfrontend efterlikna, och vilka arkitektur- och teknikval ska då gälla?
    Den befintliga experimentella HTTP-listenern är inte i bruk och utgör
    inget beslutat utgångsläge.
 
 ## Historik
 
-- Ändringar kommer att sparas i `outstanding-questions.Changelog.md`.
+- Ändringshistorik finns i `outstanding-questions.Changelog.md`.


### PR DESCRIPTION
### Motivation

- Treat the UI as an interchangeable presentation adapter so different clients (Tk, a future web frontend, test harnesses) can reuse the same, technology-neutral application contract. 
- Make the application boundary explicit to remove direct coupling between Tk widgets and mutable domain managers, enabling headless tests and easier UI migration. 
- Capture the architectural decision and a controlled, vertical migration approach to reduce migration debt and avoid large risky rewrites.

### Description

- Added `specs/architecture/ui-boundary.md` and `specs/architecture/ui-boundary.Changelog.md` defining presentation vs application vs domain responsibilities, read/write dataflows, contract rules, dependency direction, testability requirements, and a vertical migration principle. 
- Added decision `specs/decisions/2026-08-12-ui-as-adapter.md` and its changelog to record that the UI is a presentationsadapter (accepted), not a business domain. 
- Updated existing specification indexes and references: `specs/architecture/system-overview.md`, `specs/README.md`, `specs/plans/product-plan.md`, `specs/status/SPECSTATUS.md`, `specs/status/outstanding-questions.md` and their changelogs to reference the new UI boundary and to add a deferred plan item `UI-001` for a vertical migration per user-flow. 
- All changes are documentation/specification only; no production runtime code changes were introduced.

### Testing

- Repository checks (`git diff --check`) were run and reported no issues. 
- Ran the full Python test suite with `pytest`, which completed successfully with `454 passed, 115 skipped` and total coverage `89.05%`. 
- No C++/SDL2 build or tests were run because that track is experimental and has no automated tests in this repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7c223c717c83309ef79525e0da6c88)